### PR TITLE
Use the latest SDK to check ASP.NET Core is up-to-date

### DIFF
--- a/aspnetpatch-21/test.sh
+++ b/aspnetpatch-21/test.sh
@@ -3,8 +3,8 @@
 set -e
 set -x
 
-latest_aspnet_package=2.1.1
-sdks=$(dotnet --list-sdks | awk '{print $1}')
+latest_aspnet_package=2.1.3
+sdks=$(dotnet --list-sdks | awk '{print $1}' | sort -ur | head -1)
 test_folder=testapp
 
 function create_project_for_sdk_and_package()


### PR DESCRIPTION
On my Fedora machine, I had 3 SDKs installed:

```
$ dotnet --list-sdks | awk ' { print $1 } '                                                
2.1.202
2.1.302
2.1.401
```

The test was picking up 2.1.202 which does not have the latest ASP.NET Core version (2.1.3).