### PR TITLE
Source /etc/profile before running tool tests

### DIFF
--- a/tool-dev-certs/test.sh
+++ b/tool-dev-certs/test.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+if [ -f /etc/profile ]; then
+  source /etc/profile
+fi
 
 dotnet tool install --global dotnet-dev-certs
 dotnet dev-certs


### PR DESCRIPTION
Some packages modify $PATH variable to include `~/.dotnet/tools` by adding a file to `/etc/profile.d/`. This path is re-sourced on every login. But not otherwise. So the changes to `$PATH` only happen after a user logs out and back in after installing the dotnet package.

Make the tests simulate that by re-sourcing `/etc/profile` so the profile settings are re-loaded.