### PR TITLE
Generalize test for lttng for non-SCL systems

### DIFF
--- a/liblttng-ust_sys-sdt.h/test.sh
+++ b/liblttng-ust_sys-sdt.h/test.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
 
 packageName=$(rpm -qa | grep 'dotnet.*lttng-ust')
+# If a dotnet-specific lttng package doesn't exist, we must be using
+# the normal system-wide lttng package.
+if [ -z "$packageName" ]; then
+  packageName=$(rpm -qa | grep 'lttng-ust')
+fi
+
 filePath=$(rpm -ql $packageName | grep 'liblttng-ust.so.0$')
 readelf -n $filePath | grep 'NT_STAPSDT (SystemTap probe descriptors)'
 


### PR DESCRIPTION
If dotnet has been built to use the normal non-SCL/system-wide lttng package (like it is on Fedora), this test can fail.

If the lttng package is not installed via SCL, then dotnet must have been built against the system-wide lttng package. So lets just test that.