### PR TITLE
Test that dotnet --info doesn't contain missing commit ids

### DIFF
--- a/dotnet-info-commit-ids/test.json
+++ b/dotnet-info-commit-ids/test.json
@@ -1,0 +1,10 @@
+{
+  "name": "dotnet-info-commit-ids",
+  "enabled": true,
+  "version": "2.1",
+  "versionSpecific": true,
+  "type": "bash",
+  "cleanup": true,
+  "platformBlacklist":[
+  ]
+}

--- a/dotnet-info-commit-ids/test.sh
+++ b/dotnet-info-commit-ids/test.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# unofficial bash strict mode
+set -euo pipefail
+
+set -x
+
+dotnet --info
+commit_lines=($(dotnet --info | grep -i 'commit:' | sed 's/[cC]ommit://'))
+
+for line in "${commit_lines[@]}"; do
+    echo "$line"
+    if [[ $line == "N/A" ]] ; then
+        exit 1
+    fi
+done


### PR DESCRIPTION
dotnet --info will show something like "Commit: N/A" for the versions
with a bug. This fails on the latest Fedora packages, for example.

Fixes: #24