### PR TITLE
Test CLI telemetry is disabled by default

### DIFF
--- a/telemetry-is-off-by-default/test-telemetry-tcpdump.sh
+++ b/telemetry-is-off-by-default/test-telemetry-tcpdump.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+# This test is *NOT* executed by default.
+
+set -euo pipefail
+set -x
+
+# make sure all sudo invocations later on will work
+sudo echo
+
+# found via experimentation
+telemetry_host=dc.services.visualstudio.com
+
+echo "testing telemetry data"
+host ${telemetry_host}
+sudo tcpdump host "${telemetry_host}" -vv >tcp.out 2>tcp.err &
+sleep 2
+rm -rf WebTest
+mkdir -p WebTest
+pushd WebTest
+dotnet new web >/dev/null 2>&1 || true
+dotnet publish
+popd
+sleep 2
+sudo pkill tcpdump
+sleep 2
+
+cat tcp.out
+cat tcp.err
+
+# tcp dump writes out 1-byte files when no data is captured
+if [[ $(wc -c tcp.out | awk '{print $1}') != 1 ]]; then
+    echo "error: expected no captured packets"
+    exit 3
+fi
+
+echo "testing telemetry data is still sent to the same host"
+host ${telemetry_host}
+sudo tcpdump host "${telemetry_host}" -vv >tcp.out 2>tcp.err &
+sleep 2
+export DOTNET_CLI_TELEMETRY_OPTOUT=0
+dotnet new globaljson >/dev/null 2>&1 || true
+sleep 2
+sudo pkill tcpdump
+sleep 2
+
+cat tcp.out
+cat tcp.err
+
+# tcp dump writes out 1-byte files when no data is captured
+if [[ $(wc -c tcp.out | awk '{print $1}') == 1 ]]; then
+    echo "error: expected captured telemetry packets. is the telemetry being sent to a new location?"
+    exit 4
+fi
+
+echo "OK"

--- a/telemetry-is-off-by-default/test.json
+++ b/telemetry-is-off-by-default/test.json
@@ -1,0 +1,10 @@
+{
+  "name": "telemetry-is-off-by-default",
+  "enabled": true,
+  "version": "2.0",
+  "versionSpecific": false,
+  "type": "bash",
+  "cleanup": true,
+  "platformBlacklist":[
+  ]
+}

--- a/telemetry-is-off-by-default/test.sh
+++ b/telemetry-is-off-by-default/test.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# This test ensures telemetry is not being sent for (some) commands by
+# checking that no network connections are being made when not
+# expected. Relies on strace and IF_NET to detect network connections.
+#
+# A more robust version would be to use tcpdump to check for network
+# connections on each command, but this is harder to do without root
+# access.
+
+set -euo pipefail
+set -x
+
+no_server=("/nodeReuse:false" "/p:UseSharedCompilation=false" "/p:UseRazorBuildServer=false")
+
+mkdir HelloWeb
+pushd HelloWeb
+strace -e %network -fo ../new.log dotnet new web
+strace -e %network -fo ../restore.log dotnet restore "${no_server[@]}"
+strace -e %network -fo ../build.log dotnet build -c Release  "${no_server[@]}"
+popd
+rm -rf HelloWeb
+
+if grep AF_INET build.log ; then
+    echo "IF_INET not expected in build.log"
+    exit 1
+else
+    echo "OK"
+fi


### PR DESCRIPTION
There are 2 tests included here.

`test.sh` is an automated/simple test. It runs by default. It can not distinguish between a connection to a telemetry server and a connection to a nuget server.

`test-telemetry-tcpdump.sh` is not run at all. But it is more comprehensive and requires root. So it's disabled. It can distinguish between connections to a telemetry server and connections to nuget servers. It works for all commands rather than just those that do not connect to nuget.org. I found it useful for manual testing.