### PR TITLE
Fix bash tests to be more strict

### DIFF
--- a/aspnetpatch-21/test.sh
+++ b/aspnetpatch-21/test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -e
+set -euo pipefail
 set -x
 
 # Ensure we have an up-to-date value for latest_aspnet_package.

--- a/bash-completion/test.sh
+++ b/bash-completion/test.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
+set -euo pipefail
 
 ../../get-completions.sh dotnet n | grep new
 if [ $? -eq 1 ]; then

--- a/helloworld-10/test.sh
+++ b/helloworld-10/test.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -euo pipefail
+
 folder="fstest"
 mkdir $folder && pushd $folder
 

--- a/helloworld-1x/test.sh
+++ b/helloworld-1x/test.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -euo pipefail
+
 folder="cstest"
 mkdir $folder && pushd $folder
 

--- a/helloworld-2x/test.sh
+++ b/helloworld-2x/test.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -euo pipefail
+
 PROJNAME=helloworld
 
 # Test new C# project

--- a/liblttng-ust_sys-sdt.h/test.sh
+++ b/liblttng-ust_sys-sdt.h/test.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -euo pipefail
+
 packageName=$(rpm -qa | grep 'dotnet.*lttng-ust')
 # If a dotnet-specific lttng package doesn't exist, we must be using
 # the normal system-wide lttng package.

--- a/man-pages/test.sh
+++ b/man-pages/test.sh
@@ -1,16 +1,17 @@
 #!/bin/bash
 
-helpPages=$(dotnet --help | grep -A 999 'SDK commands' | grep -B 999 'Common options' | awk 'NR>1 {print $1}' | head -n-2)
-manPages=$(rpm -qd $(rpm -qa | grep 'rh-dotnet') | grep 'man1/dotnet-')
+set -euo pipefail
+
+helpPages=$(dotnet --help | grep -A 999 'SDK commands' | grep -E -B 999 'Common options|Additional commands' | awk 'NR>1 {print $1}' | head -n-2)
+manPages=$(rpm -qd $(rpm -qa | grep 'dotnet') | grep 'man1/dotnet-')
 
 for page in $helpPages;
 do
-  echo "$manPages" | grep "$page"
+  echo "$manPages" | grep "dotnet-$page"
   if [ $? -eq 1 ]; then
     echo "Man page for dotnet-$page not found: FAIL"
     exit 1
   fi
-  echo $'\n'
 done
 
 echo "All the man pages were found: PASS"

--- a/no-source-files-in-nuget/test.sh
+++ b/no-source-files-in-nuget/test.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 
-dotnet new console
+set -euo pipefail
+
+dotnet new console --force
 dotnet restore
 dotnet build
 

--- a/system-libcurl/test.sh
+++ b/system-libcurl/test.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+set -euo pipefail
 
 echo "Looking for libssl..."
 ldd $(dirname $(readlink -f $(which dotnet)))/shared/Microsoft.NETCore.App/*/System.Net.Http.Native.so | grep 'libssl.so'

--- a/system-libunwind/test.sh
+++ b/system-libunwind/test.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -euo pipefail
+
 ldd $(dirname $(readlink -f $(which dotnet)))/shared/Microsoft.NETCore.App/*/libcoreclr.so | grep 'libunwind.so'
 if [ $? -eq 1 ]; then
   echo "libunwind not found"

--- a/template-test/test.sh
+++ b/template-test/test.sh
@@ -3,15 +3,8 @@
 # this file tests templates created by
 # dotnet new <template>
 
-# override function from common.sh ( so we can have more tests in one file :) )
-function get-test-name {
-	printf "%s" "${origTestName} ( ${currentTestName} )"
-}
-
-set -e
-#set -eux
-origTestName="$( get-test-name )"
-currentTestName=""
+set -euo pipefail
+#set -x
 
 # tested templates
 # format: <template> <action>
@@ -85,7 +78,6 @@ function testTemplates {
 		if [ -n "${line:-}" ] ; then
 			templateName="${line%% *}"
 			action="${line##* }"
-			currentTestName="${templateName}"
 
 			[ -d "${tmpDir}" ]
 			mkdir -p "${tmpDir}/${templateName}-template"

--- a/tool-dev-certs/test.sh
+++ b/tool-dev-certs/test.sh
@@ -4,6 +4,10 @@ if [ -f /etc/profile ]; then
   source /etc/profile
 fi
 
+# Enable "unofficial strict mode" only after loading /etc/profile
+# because that usually contains lots of "errors".
+set -euo pipefail
+
 dotnet tool install --global dotnet-dev-certs
 dotnet dev-certs
 


### PR DESCRIPTION
The current set of tests are very very leninent with issues. Failures in pipes will make them pass. Missing commands will make them pass. Essentially, any mistake in writing a test is likely to make it pass.

This fixes the bash tests by adding the "unofficial strict mode" settings: `set -euo pipefail`.

This actually makes tests fail in more conditions, and finds a few bugs.

In particular, the man page test currently passes incorrectly, even when the logic for parsing `dotnet --help` fails to to find a single subcommand.