### PR TITLE
Allow repeated runs of tool-dev-certs test

### DIFF
--- a/tool-dev-certs/test.sh
+++ b/tool-dev-certs/test.sh
@@ -8,7 +8,9 @@ fi
 # because that usually contains lots of "errors".
 set -euo pipefail
 
-dotnet tool install --global dotnet-dev-certs
+# it's okay if the tool is already installed
+# if the tool fails to install, it will fail in the next line
+dotnet tool install --global dotnet-dev-certs || true
 dotnet dev-certs
 
 if [ $? -eq 1 ]; then


### PR DESCRIPTION
The test currently fails because `dotnet tool install` exits with an error if the tool is already installed. Ignore these errors. If the tool actually failed to install, the next line would fail anyway.