### PR TITLE
Verify that ASP.NET Core version matches the Runtime version

### DIFF
--- a/aspnet-same-runtime-version/test.json
+++ b/aspnet-same-runtime-version/test.json
@@ -1,0 +1,10 @@
+{
+  "name": "aspnet-same-runtime-version",
+  "enabled": true,
+  "version": "2.1",
+  "versionSpecific": false,
+  "type": "bash",
+  "cleanup": true,
+  "platformBlacklist":[
+  ]
+}

--- a/aspnet-same-runtime-version/test.sh
+++ b/aspnet-same-runtime-version/test.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# There's always a version of Microsoft.AspNetCore.App for each
+# version of Microsoft.NetCore.App. Make sure this is true for us too.
+
+runtime_version=$(dotnet --info  | grep '  Microsoft.NETCore.App' | awk '{ print $2 }' | sort -rh | head -1)
+echo "Latest runtime version: $runtime_version"
+
+test_folder=testapp
+
+function create_project_for_package()
+{
+  local package=$1
+
+  # create folder
+  rm -rf $test_folder
+  mkdir $test_folder
+
+  # csproj file
+  cat >$test_folder/testapp.csproj <<EOF
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="$package" />
+  </ItemGroup>
+</Project>
+EOF
+
+  # Program.cs file
+  cat >$test_folder/Program.cs <<EOF
+namespace testapp
+{
+    public class Program
+    {
+        public static void Main(string[] args) { }
+    }
+}
+EOF
+}
+
+# Verify a matching version of ASP.NET Core App/All is used
+for package in Microsoft.AspNetCore.App Microsoft.AspNetCore.All; do
+  # create project folder
+  create_project_for_package $package
+
+  # publish application
+  pushd $test_folder
+  dotnet publish -o out
+
+  # read the package version
+  package_version=$(cat out/*.deps.json | jq -r '.targets[".NETCoreApp,Version=v2.1"]["testapp/1.0.0"].dependencies["'$package'"]')
+
+  # cleanup folder
+  popd
+  rm -rf $test_folder
+
+  # check package version
+  if [[ "$package_version" == "$runtime_version" ]]; then
+    echo -e "\n==================="
+    echo "Runtime $runtime_version matches $package version $package_version PASS"
+    echo -e "===================\n"
+  else
+    echo "error: Runtime $runtime_version does not match $package $package_version FAIL"
+    exit 1
+  fi
+
+done # package


### PR DESCRIPTION
There's a matching release of ASP.NET Core for each release of .NET Core in the 2.1 lifetime so far. So verify that the default version of ASP.NET Core matches latest runtime available.

This should help us catch a situation like https://github.com/dotnet/source-build/pull/801