### PR TITLE
Add test dependencies to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,7 @@ If you forked it, replace `redhat-developer` with your username.
 git clone git@github.com:redhat-developer/dotnet-bunny.git && cd dotnet-bunny && git clone git@github.com:redhat-developer/dotnet-regular-tests.git
 ```
 
+### Dependencies
+
+Dependencies: jq bash-completion /usr/bin/readelf npm strace
+


### PR DESCRIPTION
Allows automated installation of dependencies using:

    dnf install $(grep 'Dependencies:' README.md | cut -d':' -f2-)