### PR TITLE
Add a test to make sure .NET Core uses ALPN from OpenSSL

### DIFF
--- a/openssl-alpn/test.json
+++ b/openssl-alpn/test.json
@@ -1,0 +1,10 @@
+{
+  "name": "openssl-alpn",
+  "enabled": true,
+  "version": "2.1",
+  "versionSpecific": false,
+  "type": "bash",
+  "cleanup": true,
+  "platformBlacklist":[
+  ]
+}

--- a/openssl-alpn/test.sh
+++ b/openssl-alpn/test.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# Make sure .NET Core has linked to SSL_*_alpn_* functions from OpenSSL
+
+set -euo pipefail
+set -x
+
+dotnet_dir="$(dirname $(readlink -f $(which dotnet)))"
+
+# print for  debugging
+find "${dotnet_dir}" \
+     -name System.Security.Cryptography.Native.OpenSsl.so
+
+find "${dotnet_dir}" \
+     -name System.Security.Cryptography.Native.OpenSsl.so \
+     -exec nm -D {} \; \
+     | grep SSL
+
+# This is the real check. Make sure SSL_*_alpn_* are available as dynamic symbols
+find "${dotnet_dir}" \
+     -name System.Security.Cryptography.Native.OpenSsl.so \
+     -exec nm -D {} \; \
+    | grep SSL \
+    | grep _alpn_


### PR DESCRIPTION
This adds an automated test for https://github.com/dotnet/corefx/pull/32956