### PR TITLE
Use network instead of %network with strace

### DIFF
--- a/telemetry-is-off-by-default/test.sh
+++ b/telemetry-is-off-by-default/test.sh
@@ -17,9 +17,9 @@ rm -rf HelloWeb
 
 mkdir HelloWeb
 pushd HelloWeb
-strace -e %network -fo ../new.log dotnet new web
-strace -e %network -fo ../restore.log dotnet restore "${no_server[@]}"
-strace -e %network -fo ../build.log dotnet build -c Release  "${no_server[@]}"
+strace -e network -fo ../new.log dotnet new web
+strace -e network -fo ../restore.log dotnet restore "${no_server[@]}"
+strace -e network -fo ../build.log dotnet build -c Release  "${no_server[@]}"
 popd
 rm -rf HelloWeb
 


### PR DESCRIPTION
Recent versions of strace have this in their manual page:

    -e trace=%network
    -e trace=network (deprecated)
        Trace all the network related system calls

I intentinally used the non-dprecated syntax. However, the version of strace in RHEL 7 does not support the `%network` syntax and aborts. So lets use the deprecated syntax for now.