### PR TITLE
Use nuget.config in template-test if found

### DIFF
--- a/template-test/test.sh
+++ b/template-test/test.sh
@@ -95,4 +95,9 @@ function testTemplates {
 trap cleanupFunc EXIT
 tmpDir="$( mktemp -d )"
 
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd)"
+if [[ -f "${script_dir}/nuget.config" ]]; then
+    cp "${script_dir}/nuget.config" "${tmpDir}/"
+fi
+
 testTemplates


### PR DESCRIPTION
If the test framework supplies a nuget.config, use it for running all template tests.

Otherwise, it's possible that by the time template-tests run, the required artifacts are not in the nuget cache and without a nuget.config, they wont be found.