### PR TITLE
Fix json in system-libunwind

### DIFF
--- a/system-libunwind/test.json
+++ b/system-libunwind/test.json
@@ -6,6 +6,6 @@
   "type": "bash",
   "cleanup": true,
   "platformBlacklist":[
-  rhel8
+    "rhel8"
   ]
 }


### PR DESCRIPTION
Before this patch:

    $ cat system-libunwind/test.json | json_verify
    lexical error: invalid char in json text.
                                            {   "name": "system-libunwind"
                         (right here) ------^
    JSON is invalid

The error location from this tool is bogus, but the error is real. It
can also be seen on https://jsonlint.com/ (with better error and code
location).

After:

    $ cat system-libunwind/test.json | json_verify
    JSON is valid