### PR TITLE
Fix test name in linq test

### DIFF
--- a/linq/test.json
+++ b/linq/test.json
@@ -1,5 +1,5 @@
 {
-  "name": "equality-and-sort",
+  "name": "linq",
   "enabled": true,
   "version": "1.0",
   "versionSpecific": false,


### PR DESCRIPTION
Before this, the tests might contain output like this:
```
Running equality-and-sort                                              
Result: PASS                                                 
Running bash-completion                                      
Result: PASS                                            
Running equality-and-sort 
Result: PASS
```

With `equality-and-sort` repeated multiple times.