### PR TITLE
Add a test for framework-dependent apphost

### DIFF
--- a/apphost-framework-lookup/test.json
+++ b/apphost-framework-lookup/test.json
@@ -1,0 +1,11 @@
+{
+  "name": "apphost-framework-lookup",
+  "enabled": true,
+  "version": "3.0",
+  "versionSpecific": false,
+  "type": "bash",
+  "cleanup": true,
+  "platformBlacklist":[
+  ]
+}
+

--- a/apphost-framework-lookup/test.sh
+++ b/apphost-framework-lookup/test.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -euo pipefail
+set -x
+
+mkdir bin
+cd bin
+
+dotnet new console
+dotnet publish -r linux-x64 --self-contained false
+./bin/Debug/netcoreapp3.0/linux-x64/publish/bin


### PR DESCRIPTION
Starting in .NET Core 3.0, `dotnet publish` can produce framework-dependent executibles instead of framework dependent dll files. But these can fail to work out of the box unless .NET Core is installed in a known location or DOTNET_ROOT is defined.

See https://github.com/dotnet/cli/issues/9114

cc @tmds