### PR TITLE
Restrict createdump test to .NET Core 2.2

### DIFF
--- a/createdump-aspnet/test.json
+++ b/createdump-aspnet/test.json
@@ -1,8 +1,8 @@
 {
   "name": "createdump-aspnet",
   "enabled": true,
-  "version": "2.0",
-  "versionSpecific": false,
+  "version": "2.2",
+  "versionSpecific": true,
   "type": "bash",
   "cleanup": true,
   "platformBlacklist":[


### PR DESCRIPTION
Installing global tools on .NET Core 2.1 currently pulls down a
version that needs .NET Core 2.2 to run:
https://github.com/dotnet/source-build/issues/926

So lets restrict this test to 2.2 only. The original createdump issue
that this test tries to check only affected 2.2.