### PR TITLE
Extend apphost-framework-lookup to cover 2.2 as well

### DIFF
--- a/apphost-framework-lookup/test.json
+++ b/apphost-framework-lookup/test.json
@@ -1,7 +1,7 @@
 {
   "name": "apphost-framework-lookup",
   "enabled": true,
-  "version": "3.0",
+  "version": "2.2",
   "versionSpecific": false,
   "type": "bash",
   "cleanup": true,

--- a/apphost-framework-lookup/test.sh
+++ b/apphost-framework-lookup/test.sh
@@ -8,4 +8,4 @@ cd bin
 
 dotnet new console
 dotnet publish -r linux-x64 --self-contained false
-./bin/Debug/netcoreapp3.0/linux-x64/publish/bin
+./bin/Debug/netcoreapp*/linux-x64/publish/bin


### PR DESCRIPTION
At least recent versions of the 2.2 SDK include this feature as well. 

Unsurprisingly, this feature is broken in the Fedora RPMs. It may also be broken on RHEL.

cc @tmds @RheaAyase 