### PR TITLE
Blacklist RHEL from lttng test

### DIFF
--- a/lttng/test.json
+++ b/lttng/test.json
@@ -6,5 +6,6 @@
   "type": "bash",
   "cleanup": true,
   "platformBlacklist":[
+    "rhel"
   ]
 }


### PR DESCRIPTION
The test relies on tooling not available on RHEL out of box.

We should find out if it's possible to install lttng-sessiond on RHEL
in a maintainable way and then re-enable this test when we have that.

cc @tmds @RadoslavCap @RheaAyase 