### PR TITLE
Enable bash-completion test for all versions

### DIFF
--- a/bash-completion/test.json
+++ b/bash-completion/test.json
@@ -2,7 +2,7 @@
   "name": "bash-completion",
   "enabled": true,
   "version": "2.1",
-  "versionSpecific": true,
+  "versionSpecific": false,
   "type": "bash",
   "cleanup": true,
   "platformBlacklist":[


### PR DESCRIPTION
We had disabled this in 0d5bcdc because we couldn't get it to work in some cases on some 2.2 builds. I have plan on how to fix that now; we should re-enable this test.