### PR TITLE
Check strerror_r is working for .NET Core

### DIFF
--- a/strerrorr-linkage/StrErrorLinkage.cs
+++ b/strerrorr-linkage/StrErrorLinkage.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Sockets;
+using System.Runtime.InteropServices;
+using Xunit;
+
+namespace strerror
+{
+    // Make sure that strerror_r is usable on *nix
+    public class StrErrorLinkage
+    {
+        // The SocketException constructor does an strerror_r() to
+        // resolve the error code into a string message. Assert that
+        // it works.
+        [Fact]
+        public void SocketExceptionMessageIsParsedCorrectly()
+        {
+            var se = new SocketException((int)SocketError.InvalidArgument);
+            Assert.Equal(22, se.NativeErrorCode);
+            Assert.NotEmpty(se.Message);
+            Assert.Equal("Invalid argument", se.Message);
+        }
+
+        // Manully duplicate the call that .NET Core internally does
+        // to strerror_r
+        [Fact]
+        public void ManuallyInvokingSystemNative_StrErrorRWorks()
+        {
+            var message = StrError(22);
+            Assert.NotEmpty(message);
+            Assert.Equal("Invalid argument", message);
+        }
+
+        internal const string SystemNative = "System.Native";
+
+        static unsafe string StrError(int platformErrno)
+        {
+            int maxBufferLength = 1024; // should be long enough for most any UNIX error
+            byte* buffer = stackalloc byte[maxBufferLength];
+            byte* message = StrErrorR(platformErrno, buffer, maxBufferLength);
+
+            if (message == null)
+            {
+                // This means the buffer was not large enough, but still contains
+                // as much of the error message as possible and is guaranteed to
+                // be null-terminated. We're not currently resizing/retrying because
+                // maxBufferLength is large enough in practice, but we could do
+                // so here in the future if necessary.
+                message = buffer;
+            }
+
+            return Marshal.PtrToStringAnsi((IntPtr)message);
+        }
+
+        [DllImport(SystemNative, EntryPoint = "SystemNative_StrErrorR")]
+        private static extern unsafe byte* StrErrorR(int platformErrno, byte* buffer, int bufferSize);
+    }
+}

--- a/strerrorr-linkage/strerrorr-linkage.csproj
+++ b/strerrorr-linkage/strerrorr-linkage.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <LangVersion>latest</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
+    <PackageReference Include="xunit" Version="2.3.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
+  </ItemGroup>
+
+</Project>

--- a/strerrorr-linkage/test.json
+++ b/strerrorr-linkage/test.json
@@ -1,0 +1,11 @@
+{
+  "name": "strerrorr-linkage",
+  "enabled": true,
+  "version": "1.0",
+  "versionSpecific": false,
+  "type": "xunit",
+  "cleanup": true,
+  "platformBlacklist":[
+  ]
+}
+


### PR DESCRIPTION
It's possible that `strerror_r` ends up being incorrectly linked.

Most of this test was actually written by @tmds 

See https://pagure.io/dotnet-sig/dotnet-2-2/c/44f35f6d8816c5dfd6c334a4347b9ea59ed7730f for an example where this happened.