### PR TITLE
Use a local version of get-completions.sh

### DIFF
--- a/bash-completion/get-completions.sh
+++ b/bash-completion/get-completions.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/bash
+
+get_completion_function_name_from_complete_output()
+{
+    local output=("$@")
+    local i
+    for ((i = 0; i < "${#output[@]}"; i++)); do
+        if [[ "${output[i]}" == "-F" ]]; then
+           echo "${output[((i+1))]}"
+           return 0
+        fi
+    done
+    return 1
+}
+
+get_completions()
+{
+    COMP_WORDS=("$@") # completion to test
+    #echo "COMP_WORDS: '${COMP_WORDS[@]}'"
+    COMP_LINE="$(local IFS=" "; echo "${COMP_WORDS[@]}")"
+    #echo "COMP_LINE: '$COMP_LINE'"
+    COMP_CWORD=$((${#COMP_WORDS[@]} - 1)) # index into COMP_WORDS
+    #echo "COMP_CWORD: '$COMP_CWORD'"
+    COMP_POINT="${#COMP_LINE}" # index of cursor position
+    #echo "COMP_POINT: '$COMP_POINT'"
+
+    source /usr/share/bash-completion/bash_completion
+
+    local cmd=${COMP_WORDS[0]}
+    _completion_loader "$cmd"
+
+    local output=($(complete -p "$cmd"))
+    local func=$(get_completion_function_name_from_complete_output "${output[@]}")
+
+    #_dotnet_bash_complete
+    "$func"
+
+    echo "${COMPREPLY[@]}"
+}
+
+get_completions "$@"

--- a/bash-completion/test.sh
+++ b/bash-completion/test.sh
@@ -1,20 +1,23 @@
-#!/usr/bin/env bash
+#!/usr/bin/bash
 
 set -euo pipefail
 
-../../get-completions.sh dotnet n | grep new
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+
+"$DIR"/get-completions.sh dotnet n | grep new
 if [ $? -eq 1 ]; then
   echo 'Bash completion "dotnet n" FAIL'
   exit 1
 fi
 
-../../get-completions.sh dotnet pac | grep pack
+"$DIR"/get-completions.sh dotnet pac | grep pack
 if [ $? -eq 1 ]; then
   echo 'Bash completion "dotnet pac" FAIL'
   exit 1
 fi
 
-../../get-completions.sh dotnet mig | grep migrate
+"$DIR"/get-completions.sh dotnet mig | grep migrate
 if [ $? -eq 1 ]; then
   echo 'Bash completion "dotnet mig" FAIL'
   exit 1


### PR DESCRIPTION
No point forcing the test framework to have this file. There's nothing special about it.

This will allow us to get rid of https://github.com/redhat-developer/dotnet-bunny/blob/master/get-completions.sh