### PR TITLE
Fix bash-completion test failing in a corner case

### DIFF
--- a/bash-completion/test.sh
+++ b/bash-completion/test.sh
@@ -4,19 +4,30 @@ set -euo pipefail
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
+echo "$-"
 
+echo "Step 0"
+# If this is the first time a dotnet cli command (via dotnet suggest) is
+# executed we could get the welcome message as the "completion", which most
+# shells then ignore. We end up with a blank completion. So trigger a cli
+# command manually.
+dotnet help
+
+echo "Step 1"
 "$DIR"/get-completions.sh dotnet n | grep new
 if [ $? -eq 1 ]; then
   echo 'Bash completion "dotnet n" FAIL'
   exit 1
 fi
 
+echo "Step 2"
 "$DIR"/get-completions.sh dotnet pac | grep pack
 if [ $? -eq 1 ]; then
   echo 'Bash completion "dotnet pac" FAIL'
   exit 1
 fi
 
+echo "Step 3"
 "$DIR"/get-completions.sh dotnet mig | grep migrate
 if [ $? -eq 1 ]; then
   echo 'Bash completion "dotnet mig" FAIL'


### PR DESCRIPTION
If bash-completion test is the first test run and it's running on a
system where no cli commands have ever run, the first invocation of an
SDK command (which might be completion via dotnet suggest) will cause
suprious output. That spurious output fails completion.

So check results for completion after triggering (and igoring) a SDK
command.