### PR TITLE
Add a test to make sure all dlls are built in release mode

### DIFF
--- a/dlls-in-release-mode/check-ngen-dlls
+++ b/dlls-in-release-mode/check-ngen-dlls
@@ -1,0 +1,409 @@
+#!/usr/bin/python3
+
+import ctypes
+import mmap
+import sys
+
+MAGIC_MS_DOS_HEADER_BYTES = b'MZ'
+MAGIC_MS_DOS_HEADER = int.from_bytes(MAGIC_MS_DOS_HEADER_BYTES, byteorder='little')
+
+SIGNATURE_PE = b'PE\0\0'
+
+IMAGE_FILE_MACHINE_I386 = 0x014c
+IMAGE_FILE_MACHINE_X86_64 = 0x8664
+IMAGE_FILE_MACHINE_ARM64 = 0xaa64
+IMAGE_FILE_MACHINE_ARMNT = 0x1c4
+IMAGE_FILE_MACHINE_IA64 = 0x0200
+
+IMAGE_FILE_MACHINE_NATIVE_LINUX_OVERRIDE = 0x7B79
+IMAGE_FILE_MACHINE_NATIVE_MAC_OVERRIDE = 0x4644
+
+MAGIC_PE_OPTIONAL_HEADER = 0x010b.to_bytes(2, byteorder='little')
+MAGIC_PE_OPTIONAL_HEADER64 = 0x020b.to_bytes(2, byteorder='little')
+
+# WORD = 16 bits (2 bytes) = c_ushort
+# DWORD = 32 bits (4 bytes) = c_uint
+
+class IMAGE_DOS_HEADER(ctypes.Structure):
+    _fields_ = [
+        ('e_magic', ctypes.c_ushort),
+        ('e_cblp', ctypes.c_ushort),
+        ('e_cp', ctypes.c_ushort),
+        ('e_crlc', ctypes.c_ushort),
+        ('e_cparhdr', ctypes.c_ushort),
+        ('e_minalloc', ctypes.c_ushort),
+        ('e_maxalloc', ctypes.c_ushort),
+        ('e_ss', ctypes.c_ushort),
+        ('e_sp', ctypes.c_ushort),
+        ('e_csum', ctypes.c_ushort),
+        ('e_ip', ctypes.c_ushort),
+        ('e_cs', ctypes.c_ushort),
+        ('e_lfarlc', ctypes.c_ushort),
+        ('e_ovno', ctypes.c_ushort),
+        ('e_res', ctypes.c_ushort * 4),
+        ('e_oemid', ctypes.c_ushort),
+        ('e_oeminfo', ctypes.c_ushort),
+        ('e_res2', ctypes.c_ushort * 10),
+        ('e_lfanew', ctypes.c_uint),
+    ]
+
+IMAGE_FILE_HEADER_VALID_MAGICS = {
+    IMAGE_FILE_MACHINE_I386: 'i386',
+    IMAGE_FILE_MACHINE_I386 ^ IMAGE_FILE_MACHINE_NATIVE_LINUX_OVERRIDE: 'i386 - linux',
+    IMAGE_FILE_MACHINE_I386 ^ IMAGE_FILE_MACHINE_NATIVE_MAC_OVERRIDE: 'i386 - mac',
+    IMAGE_FILE_MACHINE_X86_64: 'x86_64',
+    IMAGE_FILE_MACHINE_X86_64 ^ IMAGE_FILE_MACHINE_NATIVE_LINUX_OVERRIDE: 'x86_64 - linux',
+    IMAGE_FILE_MACHINE_X86_64 ^ IMAGE_FILE_MACHINE_NATIVE_MAC_OVERRIDE: 'x86_64 - mac',
+    IMAGE_FILE_MACHINE_ARM64: 'arm64',
+    IMAGE_FILE_MACHINE_ARM64 ^ IMAGE_FILE_MACHINE_NATIVE_LINUX_OVERRIDE: 'arm64 - linux',
+    IMAGE_FILE_MACHINE_ARM64 ^ IMAGE_FILE_MACHINE_NATIVE_MAC_OVERRIDE: 'arm64 - mac',
+    IMAGE_FILE_MACHINE_ARMNT: 'arm32',
+    IMAGE_FILE_MACHINE_ARMNT ^ IMAGE_FILE_MACHINE_NATIVE_LINUX_OVERRIDE: 'arm32 - linux',
+    IMAGE_FILE_MACHINE_IA64: 'ia64',
+}
+
+class IMAGE_FILE_HEADER(ctypes.Structure):
+    _fields_ = [
+        ('Machine', ctypes.c_ushort),
+        ('NumberOfSections', ctypes.c_ushort),
+        ('TimeDateStamp', ctypes.c_uint),
+        ('PointerToSymbolTable', ctypes.c_uint),
+        ('NumberOfSymbols', ctypes.c_uint),
+        ('SizeOfOptionalHeader', ctypes.c_ushort),
+        ('Characteristics', ctypes.c_ushort),
+    ]
+
+    def pretty_print(self):
+        print('IMAGE_FILE_HEADER: Architecture: ' + hex(self.Machine) + ' ' + IMAGE_FILE_HEADER_VALID_MAGICS[self.Machine])
+        print('IMAGE_FILE_HEADER: NumberOfSections: ' + hex(self.NumberOfSections))
+        print('IMAGE_FILE_HEADER: SizeOfOptionalHeader: ' + hex(self.SizeOfOptionalHeader))
+        print('IMAGE_FILE_HEADER: Characteristics: ' + hex(self.Characteristics))
+
+class IMAGE_DATA_DIRECTORY(ctypes.Structure):
+    _fields_ = [
+        ('VirtualAddress', ctypes.c_uint),
+        ('Size', ctypes.c_uint),
+    ]
+
+class IMAGE_OPTIONAL_HEADER(ctypes.Structure):
+    _fields_ = [
+        ('Magic', ctypes.c_ushort),
+        ('MajorLinkerVersion', ctypes.c_ubyte),
+        ('MinorLinkerVersion', ctypes.c_ubyte),
+        ('SizeOfCode', ctypes.c_uint),
+        ('SizeOfInitialzedData', ctypes.c_uint),
+        ('SizeOfUninitialzedData', ctypes.c_uint),
+        ('AddressOfEntryPoint', ctypes.c_uint),
+        ('BaseOfCode', ctypes.c_uint),
+        ('BaseOfData', ctypes.c_uint),
+        ('ImageBase', ctypes.c_uint),
+        ('SectionAlignment', ctypes.c_uint),
+        ('FileAlignment', ctypes.c_uint),
+        ('MajorOperatingSystemVersion', ctypes.c_ushort),
+        ('MinorOperatingSystemVersion', ctypes.c_ushort),
+        ('MajorImageVersion', ctypes.c_ushort),
+        ('MinorImageVersion', ctypes.c_ushort),
+        ('MajorSubsystemVersion', ctypes.c_ushort),
+        ('MinorSubsystemVersion', ctypes.c_ushort),
+        ('Win32VersionValue', ctypes.c_uint),
+        ('SizeOfImage', ctypes.c_uint),
+        ('SizeOfHeaders', ctypes.c_uint),
+        ('CheckSum', ctypes.c_uint),
+        ('Subsystem', ctypes.c_ushort),
+        ('DllCharacteristics', ctypes.c_ushort),
+        ('SizeOfStackReserve', ctypes.c_uint),
+        ('SizeOfStackCommit', ctypes.c_uint),
+        ('SizeOfHeapReserve', ctypes.c_uint),
+        ('SizeOfHeapCommit', ctypes.c_uint),
+        ('LoaderFlags', ctypes.c_uint),
+        ('NumberOfRvaAndSizes', ctypes.c_uint),
+        ('DataDirectory', IMAGE_DATA_DIRECTORY * 16),
+    ]
+
+    def pretty_print(self):
+        print('IMAGE_OPTIONAL_HEADER: Magic: ' + hex(self.Magic))
+        print('IMAGE_OPTIONAL_HEADER: AddressoFentryPoint: ' + hex(self.AddressOfEntryPoint))
+        print('IMAGE_OPTIONAL_HEADER: BaseOfCode: ' + hex(self.BaseOfCode))
+        print('IMAGE_OPTIONAL_HEADER: ImageBase: ' + hex(self.ImageBase))
+        print('IMAGE_OPTIONAL_HEADER: SizeOfImage: ' + hex(self.SizeOfImage))
+        print('IMAGE_OPTIONAL_HEADER: SizeOfHeaders: ' + hex(self.SizeOfHeaders))
+        print('IMAGE_OPTIONAL_HEADER: CheckSum: ' + hex(self.CheckSum))
+        print('IMAGE_OPTIONAL_HEADER: Subsytem: ' + hex(self.Subsystem))
+        print('IMAGE_OPTIONAL_HEADER: DllChracteristics: ' + hex(self.DllCharacteristics))
+        print('IMAGE_OPTIONAL_HEADER: NumberOfRvaAndSizes: ' + hex(self.NumberOfRvaAndSizes))
+
+        for data_directory in self.DataDirectory:
+            print('IMAGE_DATA_DIRECTORY: VirtualAddress: ' + hex(data_directory.VirtualAddress))
+            print('IMAGE_DATA_DIRECTORY: Size:' + hex(data_directory.Size))
+
+class IMAGE_OPTIONAL_HEADER64(ctypes.Structure):
+    _fields_ = [
+        ('Magic', ctypes.c_ushort),
+        ('MajorLinkerVersion', ctypes.c_ubyte),
+        ('MinorLinkerVersion', ctypes.c_ubyte),
+        ('SizeOfCode', ctypes.c_uint),
+        ('SizeOfInitialzedData', ctypes.c_uint),
+        ('SizeOfUninitialzedData', ctypes.c_uint),
+        ('AddressOfEntryPoint', ctypes.c_uint),
+        ('BaseOfCode', ctypes.c_uint),
+        ('ImageBase', ctypes.c_ulonglong),
+        ('SectionAlignment', ctypes.c_uint),
+        ('FileAlignment', ctypes.c_uint),
+        ('MajorOperatingSystemVersion', ctypes.c_ushort),
+        ('MinorOperatingSystemVersion', ctypes.c_ushort),
+        ('MajorImageVersion', ctypes.c_ushort),
+        ('MinorImageVersion', ctypes.c_ushort),
+        ('MajorSubsystemVersion', ctypes.c_ushort),
+        ('MinorSubsystemVersion', ctypes.c_ushort),
+        ('Win32VersionValue', ctypes.c_uint),
+        ('SizeOfImage', ctypes.c_uint),
+        ('SizeOfHeaders', ctypes.c_uint),
+        ('CheckSum', ctypes.c_uint),
+        ('Subsystem', ctypes.c_ushort),
+        ('DllCharacteristics', ctypes.c_ushort),
+        ('SizeOfStackReserve', ctypes.c_ulonglong),
+        ('SizeOfStackCommit', ctypes.c_ulonglong),
+        ('SizeOfHeapReserve', ctypes.c_ulonglong),
+        ('SizeOfHeapCommit', ctypes.c_ulonglong),
+        ('LoaderFlags', ctypes.c_uint),
+        ('NumberOfRvaAndSizes', ctypes.c_uint),
+        ('DataDirectory', IMAGE_DATA_DIRECTORY * 16),
+    ]
+
+    def pretty_print(self):
+        print('IMAGE_OPTIONAL_HEADER64: Magic: ' + hex(self.Magic))
+        print('IMAGE_OPTIONAL_HEADER64: AddressoFentryPoint: ' + hex(self.AddressOfEntryPoint))
+        print('IMAGE_OPTIONAL_HEADER64: BaseOfCode: ' + hex(self.BaseOfCode))
+        print('IMAGE_OPTIONAL_HEADER64: ImageBase: ' + hex(self.ImageBase))
+        print('IMAGE_OPTIONAL_HEADER64: SizeOfImage: ' + hex(self.SizeOfImage))
+        print('IMAGE_OPTIONAL_HEADER64: SizeOfHeaders: ' + hex(self.SizeOfHeaders))
+        print('IMAGE_OPTIONAL_HEADER64: CheckSum: ' + hex(self.CheckSum))
+        print('IMAGE_OPTIONAL_HEADER64: Subsytem: ' + hex(self.Subsystem))
+        print('IMAGE_OPTIONAL_HEADER64: DllChracteristics: ' + hex(self.DllCharacteristics))
+        print('IMAGE_OPTIONAL_HEADER64: NumberOfRvaAndSizes: ' + hex(self.NumberOfRvaAndSizes))
+
+        for data_directory in self.DataDirectory:
+            print('IMAGE_DATA_DIRECTORY: VirtualAddress: ' + hex(self.data_directory.VirtualAddress))
+            print('IMAGE_DATA_DIRECTORY: Size:' + hex(self.data_directory.Size))
+
+class IMAGE_SECTION_HEADER(ctypes.Structure):
+    _fields_ = [
+        ('Name', ctypes.c_ubyte * 8),
+        ('VirtualSize', ctypes.c_uint),  #FIXME actually a union
+        ('VirtualAddress', ctypes.c_uint),
+        ('SizeOfRawData', ctypes.c_uint),
+        ('PointerToRawData', ctypes.c_uint),
+        ('PointerToRelocation', ctypes.c_uint),
+        ('PointerToLinenumbers', ctypes.c_uint),
+        ('NumberOfRelocations', ctypes.c_ushort),
+        ('NumberOfLinenumbers', ctypes.c_ushort),
+        ('Characteristics', ctypes.c_uint),
+    ]
+
+    def pretty_print(self):
+        print('IMAGE_SECTION_HEADER: Name: ' + str(bytes(self.Name[0:8])))
+        print('IMAGE_SECTION_HEADER: VirtualSize: ' + str(hex(self.VirtualSize)))
+        print('IMAGE_SECTION_HEADER: VirtualAddress: ' + str(hex(self.VirtualAddress)))
+        print('IMAGE_SECTION_HEADER: SizeOfRawData: ' + hex(self.SizeOfRawData))
+        print('IMAGE_SECTION_HEADER: PointerToRawData: ' + hex(self.PointerToRawData))
+        print('IMAGE_SECTION_HEADER: PointerToRelocation: ' + hex(self.PointerToRelocation))
+        print('IMAGE_SECTION_HEADER: PointerToLinenumbers: ' + hex(self.PointerToLinenumbers))
+        print('IMAGE_SECTION_HEADER: NumberOfRelocations: ' + hex(self.NumberOfRelocations))
+        print('IMAGE_SECTION_HEADER: NumberOfLinenumbers: ' + hex(self.NumberOfLinenumbers))
+        print('IMAGE_SECTION_HEADER: Characteristics: ' + hex(self.Characteristics))
+
+class IMAGE_COR20_HEADER(ctypes.Structure):
+    _fields_ = [
+        ('cb', ctypes.c_uint),
+        ('MajorRuntimeVersion', ctypes.c_ushort),
+        ('MinorRuntimeVersion', ctypes.c_ushort),
+        ('MetaData', IMAGE_DATA_DIRECTORY),
+        ('Flags', ctypes.c_uint),
+        ('EntryPoint', ctypes.c_uint),  #FIXME this is a union
+        ('Resources', IMAGE_DATA_DIRECTORY),
+        ('StrongNameSignature', IMAGE_DATA_DIRECTORY),
+        ('CodeManagerTable', IMAGE_DATA_DIRECTORY),
+        ('VTableFixups', IMAGE_DATA_DIRECTORY),
+        ('ExportAddressTableJumps', IMAGE_DATA_DIRECTORY),
+        ('ManagedNativeHeader', IMAGE_DATA_DIRECTORY),
+    ]
+
+    def pretty_print(self):
+        print('IMAGE_COR20_HEADER: cb: ' + str(self.cb))
+        print('IMAGE_COR20_HEADER: MajorRuntimeVersion: ' + hex(self.MajorRuntimeVersion))
+        print('IMAGE_COR20_HEADER: MinorRuntimeVersion: ' + hex(self.MinorRuntimeVersion))
+        print('IMAGE_COR20_HEADER: MetaData: VirtualAddress: ' + hex(self.MetaData.VirtualAddress))
+        print('IMAGE_COR20_HEADER: MetaData: Size: ' + hex(self.MetaData.Size))
+        print('IMAGE_COR20_HEADER: Flags: ' + hex(self.Flags))
+        print('IMAGE_COR20_HEADER: EntryPoint: ' + hex(self.EntryPoint))
+        print('IMAGE_COR20_HEADER: Resources: VirtualAddress: ' + hex(self.Resources.VirtualAddress))
+        print('IMAGE_COR20_HEADER: Resources: Size: ' + hex(self.Resources.Size))
+        print('IMAGE_COR20_HEADER: StrongNameSignature: VirtualAddress: ' + hex(self.StrongNameSignature.VirtualAddress))
+        print('IMAGE_COR20_HEADER: StrongNameSignature: Size: ' + hex(self.StrongNameSignature.Size))
+        print('IMAGE_COR20_HEADER: CodeManagerTable: VirtualAddress: ' + hex(self.CodeManagerTable.VirtualAddress))
+        print('IMAGE_COR20_HEADER: CodeManagerTable: Size: ' + hex(self.CodeManagerTable.Size))
+        print('IMAGE_COR20_HEADER: VTableFixups: VirtualAddress: ' + hex(self.VTableFixups.VirtualAddress))
+        print('IMAGE_COR20_HEADER: VTableFixups: Size: ' + hex(self.VTableFixups.Size))
+        print('IMAGE_COR20_HEADER: ExportAddressTableJumps: VirtualAddress: ' + hex(self.ExportAddressTableJumps.VirtualAddress))
+        print('IMAGE_COR20_HEADER: ExportAddressTableJumps: Size: ' + hex(self.ExportAddressTableJumps.Size))
+        print('IMAGE_COR20_HEADER: ManagedNativeHeader: VirtualAddress: ' + hex(self.ManagedNativeHeader.VirtualAddress))
+        print('IMAGE_COR20_HEADER: ManagedNativeHeader: Size: ' + hex(self.ManagedNativeHeader.Size))
+
+CORCOMPILE_SIGNATURE = 0x0045474E
+READYTORUN_SIGNATURE = 0x00525452
+
+class CORCOMPILE_HEADER(ctypes.Structure):
+    _fields_ = [
+        ('Signature', ctypes.c_uint),
+        ('MajorVersion', ctypes.c_ushort),
+        ('MinorVersion', ctypes.c_ushort),
+        ('HelperTable', IMAGE_DATA_DIRECTORY),
+        ('ImportSections', IMAGE_DATA_DIRECTORY),
+        ('Dummy0', IMAGE_DATA_DIRECTORY),
+        ('StubsData', IMAGE_DATA_DIRECTORY),
+        ('VersionInfo', IMAGE_DATA_DIRECTORY),
+        ('Dependencies', IMAGE_DATA_DIRECTORY),
+        ('DebugMap', IMAGE_DATA_DIRECTORY),
+        ('ModuleImage', IMAGE_DATA_DIRECTORY),
+        ('CodeManagerTable', IMAGE_DATA_DIRECTORY),
+        ('ProfileDataList', IMAGE_DATA_DIRECTORY),
+        ('ManifestMetaData', IMAGE_DATA_DIRECTORY),
+        ('VirtualSectionsTable', IMAGE_DATA_DIRECTORY),
+        ('ImageBase', ctypes.c_ulong),
+        ('Flags', ctypes.c_uint),
+        ('PEKind', ctypes.c_uint),
+        ('COR20Flags', ctypes.c_uint),
+        ('Machine', ctypes.c_ushort),
+        ('Characteristics', ctypes.c_ushort),
+        ('EEInfoTable', IMAGE_DATA_DIRECTORY),
+        ('Dummy1', IMAGE_DATA_DIRECTORY),
+        ('Dummy2', IMAGE_DATA_DIRECTORY),
+        ('Dummy3', IMAGE_DATA_DIRECTORY),
+        ('Dummy4', IMAGE_DATA_DIRECTORY),
+    ]
+
+    def pretty_print(self):
+        print('CORCOMPILE_HEADER: Signature: ' + hex(self.Signature))
+        print('CORCOMPILE_HEADER: MajorVersion: ' + hex(self.MajorVersion))
+        print('CORCOMPILE_HEADER: MinorVersion: ' + hex(self.MinorVersion))
+        print('CORCOMPILE_HEADER: ImageBase: ' + hex(self.ImageBase))
+        print('CORCOMPILE_HEADER: VersionInfo: VirtualAddress: ' + hex(self.VersionInfo.VirtualAddress))
+        print('CORCOMPILE_HEADER: VersionInfo: Size: ' + hex(self.VersionInfo.Size))
+        print('CORCOMPILE_HEADER: Flags: ' + hex(self.Flags))
+        print('CORCOMPILE_HEADER: PEKind: ' + hex(self.PEKind))
+        print('CORCOMPILE_HEADER: COR20Flags: ' + hex(self.COR20Flags))
+        print('CORCOMPILE_HEADER: Machine: ' + hex(self.Machine))
+        print('CORCOMPILE_HEADER: Characteristics: ' + hex(self.Characteristics))
+
+
+class CORCOMPILE_VERSION_INFO(ctypes.Structure):
+    _fields_ = [
+        ('wOSPlatformID', ctypes.c_ushort),
+        ('wOSMajorVersion', ctypes.c_ushort),
+        ('wVersionMajor', ctypes.c_ushort),
+        ('wVersionMinor', ctypes.c_ushort),
+        ('wVersionBuildNumber', ctypes.c_ushort),
+        ('wVersionPrivateBuildNumber', ctypes.c_ushort),
+        ('wCodegenFlags', ctypes.c_ushort),
+        ('wConfigFlags', ctypes.c_ushort),
+        ('wBuild', ctypes.c_ushort),
+    ]
+
+
+def rva_in_range(rva, start, size):
+    return (rva >= start) and (rva < (start + size))
+
+def main(args):
+    args = args[1:]
+    for file in args:
+        with open(file, 'rb') as f:
+            mm = mmap.mmap(f.fileno(), 0, prot=mmap.PROT_READ)
+            if mm[:2] == MAGIC_MS_DOS_HEADER_BYTES:
+                dos_header = IMAGE_DOS_HEADER.from_buffer_copy(mm)
+                #print('IMAGE_DOS_HEADER: Magic : ' + hex(dos_header.e_magic) + ' ' + ascii(MAGIC_MS_DOS_HEADER_BYTES))
+                if dos_header.e_magic != MAGIC_MS_DOS_HEADER:
+                    print('error: invalid ms dos header: ' + hex(dos_header.e_magic))
+                    return 1
+
+                pe_signature = mm[dos_header.e_lfanew:dos_header.e_lfanew + 4]
+                if pe_signature != SIGNATURE_PE:
+                    print('error: invalid pe signature: ' + hex(pe_signature))
+                    return 1
+                # print('PE signature: ' + str(pe_signature))
+
+                pe_file_header_start = dos_header.e_lfanew + 4
+                pe_file_header = IMAGE_FILE_HEADER.from_buffer_copy(mm[pe_file_header_start:])
+
+                if not pe_file_header.Machine in IMAGE_FILE_HEADER_VALID_MAGICS.keys():
+                    print('error: ' + file + 'IMAGE_FILE_HEADER: unknown architecture: ' + hex(pe_file_header.Machine))
+                    return 1
+
+                pe_optional_header_magic_start = pe_file_header_start + ctypes.sizeof(pe_file_header)
+                pe_optional_header_magic = mm[pe_optional_header_magic_start: pe_optional_header_magic_start + 2]
+
+                #print('IMAGE_OPTIONAL_HEADE: Magic: ' + str(pe_optional_header_magic))
+                pe_optional_header = None
+                if pe_optional_header_magic == MAGIC_PE_OPTIONAL_HEADER64:
+                    pe_optional_header = IMAGE_OPTIONAL_HEADER64.from_buffer_copy(mm[pe_optional_header_magic_start:])
+
+                    if ctypes.sizeof(IMAGE_OPTIONAL_HEADER64) != pe_file_header.SizeOfOptionalHeader:
+                        print('error: Mismatch between expected and real optional header size')
+                        return 1
+
+                elif pe_optional_header_magic == MAGIC_PE_OPTIONAL_HEADER:
+                    pe_optional_header = IMAGE_OPTIONAL_HEADER.from_buffer_copy(mm[pe_optional_header_magic_start:])
+
+                    if ctypes.sizeof(IMAGE_OPTIONAL_HEADER) != pe_file_header.SizeOfOptionalHeader:
+                        print('error: Mismatch between expected and real optional header size. Expected ' + hex(ctypes.sizeof(IMAGE_OPTIONAL_HEADER)) + ' got ' + hex(pe_file_header.SizeOfOptionalHeader))
+                        return 1
+
+                section_header_start = pe_optional_header_magic_start + pe_file_header.SizeOfOptionalHeader
+                #print(hex(section_header_start))
+
+                for i in range(pe_file_header.NumberOfSections):
+                    section_header = IMAGE_SECTION_HEADER.from_buffer_copy(mm[section_header_start:])
+                    section_header_start += ctypes.sizeof(section_header)
+
+                # The only way to find this DataDirectory is to walk through all sections one by one
+                if pe_optional_header and (pe_optional_header.DataDirectory[14].Size != 0):
+                    cor_header_start_rva = pe_optional_header.DataDirectory[14].VirtualAddress
+                    section_header_start = pe_optional_header_magic_start + pe_file_header.SizeOfOptionalHeader
+                    for i in range(pe_file_header.NumberOfSections):
+                        section_header = IMAGE_SECTION_HEADER.from_buffer_copy(mm[section_header_start:])
+                        if rva_in_range(cor_header_start_rva, section_header.VirtualAddress, section_header.VirtualSize):
+                            file_offset = section_header.PointerToRawData + (cor_header_start_rva - section_header.VirtualAddress)
+                            # print('found COR header in section: ' + str(bytes(section_header.Name)) + ' at file offset ' + hex(file_offset))
+                            cor_header = IMAGE_COR20_HEADER.from_buffer_copy(mm[file_offset:])
+
+                            if ctypes.sizeof(IMAGE_COR20_HEADER) != cor_header.cb:
+                                print('error: Mismatch between sizeof(IMAGE_COR20_HEADER) [' + hex(ctypes.sizeof(IMAGE_COR20_HEADER)) + '] and IMAGE_COR20_HEADER.cb [' + hex(cor_header.cb) + ']')
+                                return 1
+
+                            managed_header_datadir = cor_header.ManagedNativeHeader
+                            if managed_header_datadir.VirtualAddress != 0:
+                                managed_header_offset = section_header.PointerToRawData + (managed_header_datadir.VirtualAddress - section_header.VirtualAddress)
+                                managed_header_magic_bytes = mm[managed_header_offset:managed_header_offset+4]
+                                managed_header_magic = int.from_bytes(managed_header_magic_bytes, byteorder='little')
+
+                                # print('IMAGE_COR20_HEADER: ManagedNativeReader: Magic: ' + hex(managed_header_magic))
+
+                                if managed_header_magic == CORCOMPILE_SIGNATURE:
+                                    # print('CORCOMPILE_HEADER is at VirtualAddress ' + hex(managed_header_datadir.VirtualAddress) + ' and file offset ' + hex(managed_header_offset))
+
+                                    corcompile_header = CORCOMPILE_HEADER.from_buffer_copy(mm[managed_header_offset:])
+                                    version_info_offset = section_header.PointerToRawData + (corcompile_header.VersionInfo.VirtualAddress - section_header.VirtualAddress)
+                                    version_info = CORCOMPILE_VERSION_INFO.from_buffer_copy(mm[version_info_offset:])
+                                    print(file + ': CORCOMPILE_VERSION_INFO: wBuild: ' + hex(version_info.wBuild))
+
+                                elif managed_header_magic == READYTORUN_SIGNATURE:
+                                    #print('READYTORUN_HEADER is at VirtualAddress ' + hex(managed_header_datadir.VirtualAddress) + ' and file offset ' + hex(managed_header_offset))
+                                    pass
+
+                                else:
+                                    print('error: unkown magic in IMAGE_COR20_HEADER.ManagedNativeHeader: ' + hex(managed_header_magic))
+                                    return 1
+
+                        section_header_start += ctypes.sizeof(section_header)
+
+if __name__ == '__main__':
+    sys.exit(main(sys.argv))

--- a/dlls-in-release-mode/test.json
+++ b/dlls-in-release-mode/test.json
@@ -1,0 +1,11 @@
+{
+  "name": "dlls-in-release-mode",
+  "enabled": true,
+  "version": "2.0",
+  "versionSpecific": false,
+  "type": "bash",
+  "cleanup": true,
+  "platformBlacklist":[
+  ]
+}
+

--- a/dlls-in-release-mode/test.sh
+++ b/dlls-in-release-mode/test.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# Check that all .NET Core is compiled in release mode
+#
+# - At the moment, only NGEN dlls are compiled differently for release
+#   vs debug mode
+
+set -euo pipefail
+IFS=$'\n\t'
+
+dotnet_dir=$(dirname "$(readlink -f "$(which dotnet)")")
+
+find "${dotnet_dir}" -iname '*.dll' -type f -print0 | xargs -0 ./check-ngen-dlls
+
+if find "${dotnet_dir}" -iname '*.dll' -type f -print0 | xargs -0 ./check-ngen-dlls | grep 'wBuild: 0x0'; then
+    echo "Found some dlls built in debug mode"
+    exit 1
+fi
+
+echo "PASS"
+exit 0


### PR DESCRIPTION
Currently, only NGEN-based dlls have a clear indicator of debug vs release mode.

In general, mixing debug vs release versions of coreclr and some dlls will cause coreclr to fail to start.