### PR TITLE
Disable lldb/sos test on RHEL 8

### DIFF
--- a/debugging-sos-lldb-via-core/test.json
+++ b/debugging-sos-lldb-via-core/test.json
@@ -6,6 +6,7 @@
   "type": "bash",
   "cleanup": true,
   "platformBlacklist":[
+    "rhel8"
   ]
 }
 


### PR DESCRIPTION
The test fails there (with segfaults). It needs more detailed
investigation before it can be enabled again.