### PR TITLE
Fix race between dotnet run and pgrep in debugging-sos-lldb-via-core

### DIFF
--- a/debugging-sos-lldb-via-core/test.sh
+++ b/debugging-sos-lldb-via-core/test.sh
@@ -38,11 +38,15 @@ cd TestDir
 
 dotnet new web
 sed -i -e 's|.UseStartup|.UseUrls("http://localhost:5000").UseStartup|' Program.cs
-dotnet run &
+dotnet build
+dotnet run --no-restore --no-build &
 run_pid=$!
 
-sleep 5
-exec_pid=$(pgrep --list-full --full 'dotnet exec' | cut -d' ' -f1)
+exec_pid=$(pgrep --list-full --full 'dotnet exec' | cut -d' ' -f1) || true
+while [ -z "${exec_pid}" ]; do
+    sleep 1
+    exec_pid=$(pgrep --list-full --full 'dotnet exec' | cut -d' ' -f1) || true
+done
 
 sleep 5
 


### PR DESCRIPTION
There was a race in the test case. We run `dotnet new`, `dotnet run &`
and then pgrep for `dotnet exec`. If the system running the test is
under load, then the implicit `dotnet build` might still be running by
the time we do a pgrep. At that point a `dotnet exec` process does not
exist. That puts the test in a funky state - the test has already failed
(because of set -e) but a background process is still running.

In CI systems this makes the test hang forever.

Fix that by:

- Reducing the amount of work that needs to be done in `dotnet run`

- Ignore pgrep failure and retry until we see a `dotnet exec` process