### PR TITLE
Verify that shared objects embed commit ids

### DIFF
--- a/commit-ids-in-binaries/test.json
+++ b/commit-ids-in-binaries/test.json
@@ -1,0 +1,10 @@
+{
+  "name": "commit-ids-in-binaries",
+  "enabled": true,
+  "version": "2.1",
+  "versionSpecific": false,
+  "type": "bash",
+  "cleanup": true,
+  "platformBlacklist":[
+  ]
+}

--- a/commit-ids-in-binaries/test.sh
+++ b/commit-ids-in-binaries/test.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+# .NET Core native binaries (coreclr.so, System.Native.so) contain a
+# commit id as text somewhere in the binary. For example
+#
+# $ strings System.Native.so | grep '@(#)'
+# @(#)Version 2.1.27618.01 @BuiltBy: mockbuild-d3cc2d304ed840d29d7a302f41e3a589 @SrcCode: https://github.com/dotnet/core-setup/tree/ccea2e606d948094cf861b81e15245833bfb7006
+#
+# This is then used in various places but specially when porting .NET
+# Core different architectures or bootstrapping on new platforms. For
+# an example, see https://github.com/dotnet/source-build/issues/651
+
+set -euo pipefail
+IFS=$'\n\t'
+
+set -x
+
+dotnet_home="$(dirname "$(readlink -f "$(command -v dotnet)")")"
+test -d "${dotnet_home}"
+strings -v
+
+find ${dotnet_home} -type f -name '*.so' -print0 | while IFS= read -r -d '' file; do
+    # TODO: is this a bug in this library?
+    if [ "$(basename "${file}")" == libcoreclrtraceptprovider.so ]; then
+        continue;
+    fi
+
+    echo "${file}"
+    strings "${file}" | grep '@(#)' | grep -o '[a-f0-9]\{40\}'
+done
+
+echo "OK"


### PR DESCRIPTION
It would help identify cases like https://github.com/dotnet/source-build/issues/1140 earlier.