### PR TITLE
Source /etc/profile in apphost test

### DIFF
--- a/apphost-framework-lookup/test.sh
+++ b/apphost-framework-lookup/test.sh
@@ -1,5 +1,12 @@
 #!/bin/bash
 
+if [ -f /etc/profile ]; then
+  source /etc/profile
+fi
+
+# Enable "unofficial strict mode" only after loading /etc/profile
+# because that usually contains lots of "errors".
+
 set -euo pipefail
 set -x
 


### PR DESCRIPTION
Source /etc/profile gets in definitions of DOTNET_ROOT as well as any other environment variables that are needed for .NET Core to work.