### PR TITLE
Revert "Add some debugging to some tests"

### DIFF
--- a/apphost-framework-lookup/test.sh
+++ b/apphost-framework-lookup/test.sh
@@ -10,8 +10,6 @@ fi
 set -euo pipefail
 set -x
 
-env
-
 test_publish()
 {
   name=$1

--- a/createdump-aspnet/test.sh
+++ b/createdump-aspnet/test.sh
@@ -5,8 +5,6 @@ set -euo pipefail
 
 set -x
 
-env
-
 IFS='.' read -ra VERSION_SPLIT <<< "$1"
 
 version=${VERSION_SPLIT[0]}.${VERSION_SPLIT[1]}


### PR DESCRIPTION
This reverts commit 7b173b8918a256b502c6b5e0febe69c5a6fe02ad.

No point printing environment in some tests when the framework
(dotnet-bunny) can do it:
https://github.com/redhat-developer/dotnet-bunny/commit/a3da06c0db3bca38e48bdba7ccb1ca1f72a73567