### PR TITLE
Add tests for some Japanese Eras

### DIFF
--- a/japanese-eras/JapaneseEras.cs
+++ b/japanese-eras/JapaneseEras.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using Xunit;
+
+namespace JapaneseEras
+{
+    public class JapaneseEras
+    {
+        [Theory]
+        [InlineData("2019-01-01", 4)] // Heisei
+        [InlineData("2019-04-30", 4)] // Heisei
+        [InlineData("2019-05-01", 5)] // Reiwa
+        [InlineData("2019-12-31", 5)] // Reiwa
+        public void VerifyEraIds(string date, int expectedEra)
+        {
+            var calendar = new JapaneseCalendar();
+            var time = DateTime.Parse(date);
+            int era = calendar.GetEra(time);
+            Assert.Equal(expectedEra, era);
+        }
+
+        [Theory]
+        [InlineData("2019-01-01", "平成")] // Heisei
+        [InlineData("2019-04-30", "平成")] // Heisei
+        [InlineData("2019-05-01", "令和")] // Reiwa
+        [InlineData("2019-12-31", "令和")] // Reiwa
+        public void VerifyEraNames(string date, string expectedEra)
+        {
+            CultureInfo japaneseCulture = new CultureInfo("ja-JP");
+            var calendar = new JapaneseCalendar();
+            japaneseCulture.DateTimeFormat.Calendar = calendar;
+
+            var eraTime = DateTime.Parse(date);
+
+            Assert.Equal(expectedEra, eraTime.ToString("gg", japaneseCulture));
+        }
+    }
+}

--- a/japanese-eras/japanese-eras.csproj
+++ b/japanese-eras/japanese-eras.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
+    <PackageReference Include="xunit" Version="2.3.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
+  </ItemGroup>
+</Project>

--- a/japanese-eras/test.json
+++ b/japanese-eras/test.json
@@ -1,0 +1,11 @@
+{
+  "name": "japanese-eras",
+  "enabled": true,
+  "version": "2.1",
+  "versionSpecific": false,
+  "type": "xunit",
+  "cleanup": true,
+  "platformBlacklist":[
+  ]
+}
+


### PR DESCRIPTION
This was specially called out in the .NET Core 3.0 Preview 5 release
notes under "New Japanese Era (Reiwa)":
https://devblogs.microsoft.com/dotnet/announcing-net-core-3-0-preview-5/

I am not sure if it's supported on older .NET Core versions; it should be.

For more about calendars, see:

- https://devblogs.microsoft.com/dotnet/handling-a-new-era-in-the-japanese-calendar-in-net/
- https://docs.microsoft.com/en-us/dotnet/standard/datetime/working-with-calendars