### PR TITLE
Verify the APIs return correct .NET Core versions

### DIFF
--- a/version-apis/VersionTest.cs
+++ b/version-apis/VersionTest.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Reflection;
+using System.Runtime.InteropServices;
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace DotNetCoreVersionApis
+{
+    public class VersionTest
+    {
+        [Fact]
+        public void EnvironmentVersion()
+        {
+            var version = Environment.Version;
+            Console.WriteLine($"Environment.Version: {version}");
+            Assert.Equal(3, version.Major);
+        }
+
+        [Fact]
+        public void RuntimeInformationFrameworkDescription()
+        {
+            var description = RuntimeInformation.FrameworkDescription;
+            Console.WriteLine($"RuntimeInformation.FrameworkDescription: {description}");
+            Assert.StartsWith(".NET Core 3.", description);
+        }
+
+        [Theory]
+        [InlineData("coreclr", typeof(object))]
+        [InlineData("corefx", typeof(Uri))]
+        public void CommitHashesAreAvailable(string repo, Type type)
+        {
+            Console.WriteLine($"Testing commit hashes for {repo}");
+
+            var attributes = (AssemblyInformationalVersionAttribute[])type.Assembly.GetCustomAttributes(typeof(AssemblyInformationalVersionAttribute),false);
+            var versionAttribute = attributes[0];
+            Console.WriteLine($"AssemblyInformationVersionAttribute: {versionAttribute.InformationalVersion}");
+
+            string[] versionParts = versionAttribute.InformationalVersion.Split("+");
+            Assert.Equal(2, versionParts.Length);
+
+            string fullVersion = versionParts[0];
+            string plainVersion = fullVersion.Split("-")[0];
+
+            Assert.Matches(new Regex("\\d+(\\.\\d)+"), plainVersion);
+
+            bool okay = Version.TryParse(plainVersion, out Version parsedVersion);
+            Assert.True(okay);
+            Assert.Equal(3, parsedVersion.Major);
+
+            var commitId = versionParts[1];
+            Regex commitRegex = new Regex("[0-9a-fA-F]{40}");
+
+            Assert.Matches(commitRegex, commitId);
+        }
+    }
+}

--- a/version-apis/test.json
+++ b/version-apis/test.json
@@ -1,0 +1,11 @@
+{
+  "name": "version-apis",
+  "enabled": true,
+  "version": "3.0",
+  "versionSpecific": false,
+  "type": "xunit",
+  "cleanup": true,
+  "platformBlacklist":[
+  ]
+}
+

--- a/version-apis/version-apis.csproj
+++ b/version-apis/version-apis.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <RootNamespace>DotNetCoreVersionApis</RootNamespace>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+    <PackageReference Include="xunit" Version="2.4.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+    <PackageReference Include="coverlet.collector" Version="1.0.1" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
These APIs have been modified in 3.0 to return correct values instead of
fake .NET Framework values.

They also rely on commit ids being present in the compiled CoreCLR and
CoreFX projects.