### PR TITLE
use https to git clone for ease of use

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Please see the repository for more details: https://github.com/redhat-developer/
 If you forked it, replace `redhat-developer` with your username.
 
 ```
-git clone git@github.com:redhat-developer/dotnet-bunny.git && cd dotnet-bunny && git clone git@github.com:redhat-developer/dotnet-regular-tests.git
+$ git clone https://github.com/redhat-developer/dotnet-bunny && cd dotnet-bunny && git clone https://github.com/redhat-developer/dotnet-regular-tests
 ```
 
 ### Dependencies


### PR DESCRIPTION
if we use https, we don't have to clone the repo and can start playing immediately 🎈 

tested on ubuntu xenial 

$ git clone https://github.com/redhat-developer/dotnet-bunny && cd dotnet-bunny && git clone https://github.com/redhat-developer/dotnet-regular-tests
Cloning into 'dotnet-bunny'...
remote: Enumerating objects: 30, done.
remote: Counting objects: 100% (30/30), done.
remote: Compressing objects: 100% (21/21), done.
remote: Total 217 (delta 18), reused 14 (delta 9), pack-reused 187
Receiving objects: 100% (217/217), 50.50 KiB | 10.10 MiB/s, done.
Resolving deltas: 100% (132/132), done.
Cloning into 'dotnet-regular-tests'...
remote: Enumerating objects: 100, done.
remote: Counting objects: 100% (100/100), done.
remote: Compressing objects: 100% (78/78), done.
remote: Total 694 (delta 35), reused 63 (delta 22), pack-reused 594
Receiving objects: 100% (694/694), 107.76 KiB | 6.73 MiB/s, done.
Resolving deltas: 100% (311/311), done.


$ git clone git@github.com:redhat-developer/dotnet-bunny.git && cd dotnet-bunny && git clone git@github.com:redhat-developer/dotnet-regular-tests.git
Cloning into 'dotnet-bunny'...
The authenticity of host 'github.com (140.82.114.4)' can't be established.
RSA key fingerprint is SHA256:nThbg6kXUpJWGl7E1IGOCspRomTxdCARLviKw6E5SY8.
Are you sure you want to continue connecting (yes/no)? yes
Warning: Permanently added 'github.com,140.82.114.4' (RSA) to the list of known hosts.
git@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.