### PR TITLE
Add tests to make sure binaries are hardened

### DIFF
--- a/hardened-binaries/test.json
+++ b/hardened-binaries/test.json
@@ -1,0 +1,11 @@
+{
+  "name": "hardened-binaries",
+  "enabled": true,
+  "version": "3.0",
+  "versionSpecific": false,
+  "type": "bash",
+  "cleanup": true,
+  "platformBlacklist":[
+
+  ]
+}

--- a/hardened-binaries/test.sh
+++ b/hardened-binaries/test.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -euo pipefail
+IFS=$'\n\t'
+
+root=$(dirname "$(readlink -f "$(command -v dotnet)")")
+echo ".NET Core base directory: $root"
+
+# TODO handle more architectures can just x86-64
+
+file_list=$(find "$root/" -type f -exec file {} \; | grep 'ELF 64-bit LSB' | cut -d: -f 1 | sort -u)
+mapfile -t binaries <<< "$file_list"
+for binary in "${binaries[@]}"; do
+    echo "$binary"
+    # Check for full Relocation Read-Only (aka RELRO)
+    readelf -l "$binary" | grep GNU_RELRO
+    readelf -d "$binary" | grep BIND_NOW
+done


### PR DESCRIPTION
As a bonus, this allows us to verify that the binaries were compiled by us and are not prebuilts accidentally leaked into our builds.