### PR TITLE
Verify the host from the SDK is usable

### DIFF
--- a/use-apphost-from-sdk/test.json
+++ b/use-apphost-from-sdk/test.json
@@ -1,0 +1,11 @@
+{
+  "name": "use-apphost-from-sdk",
+  "enabled": true,
+  "version": "3.0",
+  "versionSpecific": false,
+  "type": "bash",
+  "cleanup": true,
+  "platformBlacklist":[
+
+  ]
+}

--- a/use-apphost-from-sdk/test.sh
+++ b/use-apphost-from-sdk/test.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/bash
+
+set -euo pipefail
+IFS=$'\n\t'
+
+rm -rf console
+mkdir console
+pushd console
+
+# Verify that the apphost from the SDK is usable and nuget is not
+# needed for building a HelloWorld console application.
+
+cat > nuget.config <<EOF
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+  </packageSources>
+</configuration>
+EOF
+
+dotnet new console
+dotnet build --no-restore
+netcoreapp=( bin/Debug/netcoreapp* )
+"${netcoreapp[0]}"/console
+
+popd


### PR DESCRIPTION
This is the other side of
https://github.com/dotnet/source-build/issues/1202. In this case the
apphost is not known and the SDK downloads the host from nuget.org
instead of using the host that is included with the sdk.

cc @tmds 