### PR TITLE
Dont test hardening on RHEL 7

### DIFF
--- a/hardened-binaries/test.json
+++ b/hardened-binaries/test.json
@@ -6,6 +6,6 @@
   "type": "bash",
   "cleanup": true,
   "platformBlacklist":[
-
+    "rhel7"
   ]
 }


### PR DESCRIPTION
RHEL 7 is not hardended with full RELRO. It doesn't use `BIND_NOW` (`-Wl,-z,now`) linker flags.