### PR TITLE
Enable lttng/sdt.h integration tests

### DIFF
--- a/liblttng-ust_sys-sdt.h/test.json
+++ b/liblttng-ust_sys-sdt.h/test.json
@@ -6,7 +6,6 @@
   "type": "bash",
   "cleanup": true,
   "platformBlacklist":[
-    "fedora",
-    "rhel8"
+    "fedora31"
   ]
 }


### PR DESCRIPTION
It ought to be supported on both Fedora [1] and RHEL 8 now.

[1] https://bugzilla.redhat.com/show_bug.cgi?id=1386412