### PR TITLE
Initial support for .NET 5

### DIFF
--- a/apphost-framework-lookup/test.sh
+++ b/apphost-framework-lookup/test.sh
@@ -18,7 +18,7 @@ test_publish()
   mkdir $name && pushd $name
   dotnet new console
   dotnet publish -r "$runtime_id" --self-contained $2
-  ./bin/Debug/netcoreapp*/"$runtime_id"/publish/$name
+  ./bin/Debug/net*/"$runtime_id"/publish/$name
   popd
 }
 

--- a/helloworld-2x/test.sh
+++ b/helloworld-2x/test.sh
@@ -23,7 +23,7 @@ echo -e "===================\n"
 
 dotnet new console --language F# --name $PROJNAME
 pushd $PROJNAME
-dotnet run | grep 'Hello World from F#!'
+dotnet run | grep -i 'Hello World from F#'
 if [ $? -eq 1 ]; then
   echo "F# Hello World FAIL"
   rm -rf $PROJNAME

--- a/libuv-kestrel-sample-app/Startup.cs
+++ b/libuv-kestrel-sample-app/Startup.cs
@@ -36,7 +36,8 @@ namespace SampleApp
                 {
                     await next.Invoke();
                 }
-                catch (BadHttpRequestException ex) when (ex.StatusCode == StatusCodes.Status413RequestEntityTooLarge) { }
+                // Need to fully qualify BadHttpRequestException to stay compatible across different versions
+                catch (Microsoft.AspNetCore.Server.Kestrel.Core.BadHttpRequestException ex) when (ex.StatusCode == StatusCodes.Status413RequestEntityTooLarge) { }
             });
 
             app.Run(async context =>

--- a/libuv-kestrel-sample-app/test.sh
+++ b/libuv-kestrel-sample-app/test.sh
@@ -6,7 +6,7 @@ set -x
 
 dotnet restore
 dotnet build
-dotnet bin/Debug/netcoreapp*/libuv-kestrel-sample-app.dll &
+dotnet bin/Debug/net*/libuv-kestrel-sample-app.dll &
 root_pid=$!
 
 sleep 5

--- a/use-apphost-from-sdk/test.sh
+++ b/use-apphost-from-sdk/test.sh
@@ -21,7 +21,7 @@ EOF
 
 dotnet new console
 dotnet build --no-restore
-netcoreapp=( bin/Debug/netcoreapp* )
+netcoreapp=( bin/Debug/net* )
 "${netcoreapp[0]}"/console
 
 popd

--- a/version-apis/VersionTest.cs
+++ b/version-apis/VersionTest.cs
@@ -13,7 +13,7 @@ namespace DotNetCoreVersionApis
         {
             var version = Environment.Version;
             Console.WriteLine($"Environment.Version: {version}");
-            Assert.Equal(3, version.Major);
+            Assert.InRange(version.Major, 3, 5);
         }
 
         [Fact]
@@ -21,7 +21,7 @@ namespace DotNetCoreVersionApis
         {
             var description = RuntimeInformation.FrameworkDescription;
             Console.WriteLine($"RuntimeInformation.FrameworkDescription: {description}");
-            Assert.StartsWith(".NET Core 3.", description);
+            Assert.StartsWith(".NET", description);
         }
 
         [Theory]
@@ -45,7 +45,7 @@ namespace DotNetCoreVersionApis
 
             bool okay = Version.TryParse(plainVersion, out Version parsedVersion);
             Assert.True(okay);
-            Assert.Equal(3, parsedVersion.Major);
+            Assert.InRange(parsedVersion.Major, 3, 5);
 
             var commitId = versionParts[1];
             Regex commitRegex = new Regex("[0-9a-fA-F]{40}");


### PR DESCRIPTION
This contains a grab bag of fixes:

- The framework has changed from `netcoreapp*` to `net5.0`. We need to shorten the string used to search for the framework in various tests.

- The Hello-World F# example uses different casing and has no exclamation mark at the end. Relax the string match requirements to support that.

- There are now multiple implementations of BadHttpRequestException available. Fully qualify it.

- Relax the version checks to support the bump from 3.x to 5.0.

With these fixes, there are still about 5 test failures. Some are bugs in source-build. Others would be better addressed via https://github.com/redhat-developer/dotnet-bunny/issues/34