### PR TITLE
Add logging to aspnet runtime version 2x test

### DIFF
--- a/aspnet-same-runtime-version-2x/test.sh
+++ b/aspnet-same-runtime-version-2x/test.sh
@@ -2,6 +2,8 @@
 
 set -euo pipefail
 
+set -x
+
 # There's always a version of Microsoft.AspNetCore.App for each
 # version of Microsoft.NetCore.App. Make sure this is true for us too.
 


### PR DESCRIPTION
Add some logging information so we can see what's going on in case this test fails.