### PR TITLE
Centralize how .NET directoires are looked up

### DIFF
--- a/bundled-libunwind/test.sh
+++ b/bundled-libunwind/test.sh
@@ -4,8 +4,10 @@ set -euo pipefail
 
 set -x
 
+framework_dir=$(../dotnet-directory --framework "$1")
+
 set +e
-ldd $(dirname $(readlink -f $(which dotnet)))/shared/Microsoft.NETCore.App/*/libcoreclr.so | grep 'libunwind.so'
+ldd "${framework_dir}/libcoreclr.so" | grep 'libunwind.so'
 retval=$?
 set -e
 if [ $retval -eq 1 ]; then
@@ -16,7 +18,7 @@ else
 fi
 
 set +e
-ldd $(dirname $(readlink -f $(which dotnet)))/shared/Microsoft.NETCore.App/*/libcoreclr.so | grep 'libunwind-x86_64.so'
+ldd "${framework_dir}/libcoreclr.so" | grep 'libunwind-x86_64.so'
 retval=$?
 set -e
 if [ $retval -eq 1 ]; then

--- a/curl-certificate-store/test.sh
+++ b/curl-certificate-store/test.sh
@@ -2,8 +2,10 @@
 
 set -euo pipefail
 
-dotnet=$(command -v dotnet)
-ldd_line=$(ldd "$(dirname "$(readlink -f "$dotnet")")"/shared/Microsoft.NETCore.App/*/System.Net.Http.Native.so | grep -E 'libcurl.so')
+framework_dir=$(../dotnet-directory --framework "$1")
+system_net_native="${framework_dir}/System.Net.Http.Native.so"
+
+ldd_line=$(ldd "$system_net_native" | grep -E 'libcurl.so')
 echo "$ldd_line"
 libcurl=$(echo "$ldd_line" | awk '{ print $3 }')
 ca_bundle=$(strings "$libcurl" | grep crt)

--- a/debugging-sos-lldb-via-core-2x/test.sh
+++ b/debugging-sos-lldb-via-core-2x/test.sh
@@ -29,12 +29,7 @@ sdk_version=$1
 
 set -x
 
-# TODO: assert that this is only one directory
-declare -a versions
-IFS='.' read -ra versions <<< "${sdk_version}"
-framework_dir="$(ls -d "$(dirname "$(readlink -f "$(command -v dotnet)")")/shared/Microsoft.NETCore.App/${versions[0]}.${versions[1]}"*)"
-echo "${framework_dir}"
-test -d "${framework_dir}"
+framework_dir=$(../dotnet-directory --framework "${sdk_version}")
 test -f "${framework_dir}/createdump"
 
 if ! command -v lldb ; then

--- a/debugging-sos-lldb-via-core/test.sh
+++ b/debugging-sos-lldb-via-core/test.sh
@@ -39,12 +39,7 @@ dotnet tool install -g dotnet-dump --version 3.0.0
 
 dotnet sos install
 
-# TODO: assert that this is only one directory
-declare -a versions
-IFS='.' read -ra versions <<< "${sdk_version}"
-framework_dir="$(ls -d "$(dirname "$(readlink -f "$(command -v dotnet)")")/shared/Microsoft.NETCore.App/${versions[0]}.${versions[1]}"*)"
-echo "${framework_dir}"
-test -d "${framework_dir}"
+framework_dir=$(../dotnet-directory --framework "${sdk_version}")
 test -f "${framework_dir}/createdump"
 
 if ! command -v lldb ; then

--- a/dotnet-directory
+++ b/dotnet-directory
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+# This is a script called by multiple tests to find the runtime
+# directory of the current platform.
+
+set -euo pipefail
+
+function usage() {
+    echo "usage: $0 [--home | --framework] <version>"
+    echo ""
+    echo "Shows a .NET directory."
+}
+
+print_home=0
+print_framework=0
+
+positional_args=()
+while [[ $# -gt 0 ]]; do
+    arg=$1
+    shift
+    case "$arg" in
+        --home) print_home=1 ;;
+        --framework) print_framework=1 ;;
+        --*) usage; exit 1 ;;
+        *)
+            positional_args+=("$arg")
+            ;;
+    esac
+done
+
+version=${positional_args[0]:-}
+if [[ -z ${version} ]]; then
+    echo "error: missing argument."
+    usage
+    exit 1
+fi
+
+declare -a versions
+IFS='.' read -ra versions <<< "${version}"
+dotnet_dir=$(dirname "$(readlink -f "$(command -v dotnet)")")
+framework_dirs=( "${dotnet_dir}/shared/Microsoft.NETCore.App/${versions[0]}.${versions[1]}"* )
+framework_dir="${framework_dirs[0]}"
+
+if [[ ${print_home} == 1 ]]; then
+    echo "${dotnet_dir}"
+elif [[ ${print_framework} == 1 ]]; then
+    echo "${framework_dir}"
+else
+    echo "error"
+    exit 1
+fi

--- a/managed-symbols-available/test.sh
+++ b/managed-symbols-available/test.sh
@@ -5,18 +5,11 @@
 set -euo pipefail
 IFS=$'\n\t'
 
-sdk_version=$1
-IFS='.' read -ra VERSION_SPLIT <<< "$sdk_version"
-runtime_version=${VERSION_SPLIT[0]}.${VERSION_SPLIT[1]}
-
 ignore_cases=(
     System.Runtime.CompilerServices.Unsafe.dll
 )
 
-dotnet_dir=$(dirname "$(readlink -f "$(which dotnet)")")
-
-framework_dirs=("${dotnet_dir}/shared/Microsoft.NETCore.App/${runtime_version}"*)
-framework_dir="${framework_dirs[0]}"
+framework_dir=$(../dotnet-directory --framework "$1")
 
 find "${framework_dir}" -name '*.dll' -type f | sort -u | while read dll_name; do
     base_dll_name=$(basename "${dll_name}")

--- a/openssl-alpn/test.sh
+++ b/openssl-alpn/test.sh
@@ -5,7 +5,7 @@
 set -euo pipefail
 set -x
 
-dotnet_dir="$(dirname $(readlink -f $(which dotnet)))"
+dotnet_dir="$(../dotnet-directory --home "$1")"
 
 # print for  debugging
 find "${dotnet_dir}" \

--- a/system-libcurl/test.sh
+++ b/system-libcurl/test.sh
@@ -2,15 +2,17 @@
 
 set -euo pipefail
 
+framework_dir=$(../dotnet-directory --framework "$1" )
+
 echo "Looking for libssl..."
-ldd $(dirname $(readlink -f $(which dotnet)))/shared/Microsoft.NETCore.App/*/System.Net.Http.Native.so | grep 'libssl.so'
+ldd "${framework_dir}/System.Net.Http.Native.so" | grep 'libssl.so'
 if [ $? -eq 1 ]; then
   echo "libssl not found"
   exit 1
 fi
 
 echo "Looking for libcurl..."
-ldd $(dirname $(readlink -f $(which dotnet)))/shared/Microsoft.NETCore.App/*/System.Net.Http.Native.so | grep -E 'libcurl.so|libcurl-libcurl-httpd24.so'
+ldd "${framework_dir}/System.Net.Http.Native.so" | grep -E 'libcurl.so|libcurl-libcurl-httpd24.so'
 if [ $? -eq 1 ]; then
   echo "libcurl not found"
   exit 1

--- a/system-libunwind/test.sh
+++ b/system-libunwind/test.sh
@@ -2,13 +2,15 @@
 
 set -euo pipefail
 
-ldd $(dirname $(readlink -f $(which dotnet)))/shared/Microsoft.NETCore.App/*/libcoreclr.so | grep 'libunwind.so'
+framework_dir=$(../dotnet-directory --framework "$1")
+
+ldd "${framework_dir}/libcoreclr.so" | grep 'libunwind.so'
 if [ $? -eq 1 ]; then
   echo "libunwind not found"
   exit 1
 fi
 
-ldd $(dirname $(readlink -f $(which dotnet)))/shared/Microsoft.NETCore.App/*/libcoreclr.so | grep 'libunwind-x86_64.so'
+ldd "${framework_dir}/libcoreclr.so" | grep 'libunwind-x86_64.so'
 if [ $? -eq 1 ]; then
   echo "libunwind-x86_64 not found"
   exit 1


### PR DESCRIPTION
The new script `dotnet-directory` allows everyone to consistently find the location of things related to .NET:

- The main installation directory

  Eg: /usr/lib64/dotnet

- The shared framework directory

  Eg: /usr/lib64/dotnet/shared/Microsoft.NETCore.App/3.1.5/

This makes it easier to modify things if the directory paths ever change. We should also get more consistent behaviour if more than one runtime version is installed.