### PR TITLE
System.Net.Http.Native.so has been removed in .NET 5

### DIFF
--- a/curl-certificate-store/test.sh
+++ b/curl-certificate-store/test.sh
@@ -5,6 +5,11 @@ set -euo pipefail
 framework_dir=$(../dotnet-directory --framework "$1")
 system_net_native="${framework_dir}/System.Net.Http.Native.so"
 
+if [ ! -f "${system_net_native}" ]; then
+    echo "${system_net_native} not found. Nothing to test."
+    exit 0
+fi
+
 ldd_line=$(ldd "$system_net_native" | grep -E 'libcurl.so')
 echo "$ldd_line"
 libcurl=$(echo "$ldd_line" | awk '{ print $3 }')

--- a/system-libcurl/test.sh
+++ b/system-libcurl/test.sh
@@ -3,16 +3,22 @@
 set -euo pipefail
 
 framework_dir=$(../dotnet-directory --framework "$1" )
+system_net_native="${framework_dir}/System.Net.Http.Native.so"
+
+if [ ! -f "${system_net_native}" ]; then
+    echo "${system_net_native} not found. Nothing to test."
+    exit 0
+fi
 
 echo "Looking for libssl..."
-ldd "${framework_dir}/System.Net.Http.Native.so" | grep 'libssl.so'
+ldd "${system_net_native}" | grep 'libssl.so'
 if [ $? -eq 1 ]; then
   echo "libssl not found"
   exit 1
 fi
 
 echo "Looking for libcurl..."
-ldd "${framework_dir}/System.Net.Http.Native.so" | grep -E 'libcurl.so|libcurl-libcurl-httpd24.so'
+ldd "${system_net_native}" | grep -E 'libcurl.so|libcurl-libcurl-httpd24.so'
 if [ $? -eq 1 ]; then
   echo "libcurl not found"
   exit 1


### PR DESCRIPTION
Treat the test as passing if that file is not found.

Alternatively, we can limit the tests to .NET versions less than 5.