### PR TITLE
Show all results in file-permissions before failing

### DIFF
--- a/file-permissions/test.sh
+++ b/file-permissions/test.sh
@@ -3,26 +3,34 @@
 set -euo pipefail
 IFS=$'\n\t'
 
+errors=0
+
 dotnet_home="$(dirname "$(readlink -f "$(command -v dotnet)")")"
 test -d "${dotnet_home}"
 
-find "${dotnet_home}" -type f -print0 | while IFS= read -r -d '' file; do
+while IFS= read -r -d '' file; do
     echo "$(stat -c "%A" "${file}") ${file}"
 
     # Everything should be readable by user, group, and other. There's no secret data in any of these files.
     if [[ "$(stat -c "%A" "${file}" | tr -d -c 'r' | awk '{ print length; }')" -ne 3 ]]; then
         echo "error: Missing read permissions on ${file}"
-        exit 1
+        errors=1
     fi
 
     # If it's executable, it must be executable by all
     if stat -c "%A" "${file}" | grep 'x' ; then
         if [[ $(stat -c "%A" "${file}" | tr -d -c 'x' | awk '{print length; }') -ne 3 ]]; then
             echo "error: Missing some execute permissions on ${file}"
-            exit 1
+            errors=1
         fi
     fi
 
-done
+done < <(find "${dotnet_home}" -type f -print0)
 
-echo "OK"
+if [[ "$errors" == 1 ]]; then
+  echo "Errors detected"
+  exit 1
+else
+  echo "OK"
+  exit 0
+fi


### PR DESCRIPTION
By showing all the errors at once, it's possible to fix all the issues at once in the SDK. Otherwise, currently, we have to fix the SDK, re-run this test, fix additional issues in the SDK and re-run this test until it passes.