### PR TITLE
extract-bundle-dir is only valid for 3.1

### DIFF
--- a/extract-bundle-dir/test.json
+++ b/extract-bundle-dir/test.json
@@ -3,7 +3,7 @@
   "enabled": true,
   "requiresSdk": true,
   "version": "3.1",
-  "versionSpecific": false,
+  "versionSpecific": true,
   "type": "bash",
   "cleanup": true,
   "ignoredRIDs":[

--- a/extract-bundle-dir/test.sh
+++ b/extract-bundle-dir/test.sh
@@ -28,6 +28,7 @@ rm -rf $APP_EXTRACT_DIR
 
 # Create a single file executable.
 dotnet new console -o $APP_NAME
+sed -E -i '/Console.WriteLine/ a     Console.WriteLine(AppContext.BaseDirectory);' $APP_NAME/Program.cs
 dotnet publish -r $(../runtime-id --portable) /p:PublishSingleFile=true $APP_NAME -o published
 
 # Execute the single file, which will cause it to extract.


### PR DESCRIPTION
This feature was introduced with .NET Core 3.0 (now EOL). In .NET 5.0, the single standalone file is not extracted to a on-disk location. This test is not needed there. Because the bundle extraction directory is empty, the test also results in a false positive.

See https://github.com/dotnet/runtime/issues/36590 for more information.