### PR TITLE
Test that the system-version of OpenSSL is used directly

### DIFF
--- a/system-openssl/test.json
+++ b/system-openssl/test.json
@@ -1,0 +1,11 @@
+{
+  "name": "system-openssl",
+  "enabled": true,
+  "requiresSdk": false,
+  "version": "2.1",
+  "versionSpecific": false,
+  "type": "bash",
+  "cleanup": true,
+  "ignoredRIDs":[
+  ]
+}

--- a/system-openssl/test.sh
+++ b/system-openssl/test.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-# Make sure .NET Core has linked to SSL_*_alpn_* functions from OpenSSL
+# Make sure .NET has ldd-visible links to OpenSSL. We prefer that over
+# using OpenSSL via dlopen (which is more likely to fail at runtime).
 
 set -euo pipefail
 set -x
@@ -15,12 +16,10 @@ find "${dotnet_dir}" \
 
 find "${dotnet_dir}" \
      "${find_ssl_args[@]}" \
-     -exec nm -D {} \; \
-     | grep SSL
+     -exec ldd {} \; \
+    | grep -E '(libcrypto|libssl)'
 
-# This is the real check. Make sure SSL_*_alpn_* are available as dynamic symbols
 find "${dotnet_dir}" \
      "${find_ssl_args[@]}" \
      -exec nm -D {} \; \
-    | grep SSL \
-    | grep _alpn_
+     | grep SSL


### PR DESCRIPTION
Instead of via dlopen(). This flags issues like https://github.com/dotnet/runtime/issues/41768 early for us.

This includes a revert of commit 37a39cb79465bc9e0fcb2364c771f78983b449ac too. I (now) think it makes sense to flag this as a test failure to catch ALPN being broken/missing ASAP.