### PR TITLE
Update versions in CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,5 +12,5 @@ $ git clone https://github.com/redhat-developer/dotnet-bunny && cd dotnet-bunny 
 
 ### Dependencies
 
-Dependencies: babeltrace bash-completion findutils jq lttng-tools npm strace /usr/bin/free /usr/bin/lldb /usr/bin/readelf which
+Dependencies: babeltrace bash-completion findutils jq lttng-tools npm strace /usr/bin/free /usr/bin/lldb /usr/bin/readelf /usr/bin/file which
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,13 +1,12 @@
 
 resources:
   containers:
-  - container: fedora-30
-    image: fedora:30
-    options: --cap-add all --security-opt seccomp=unconfined --privileged
-
+  - container: fedora-32
+    image: fedora:32
+  - container: fedora-33
+    image: fedora:33
   - container: fedora-rawhide
     image: fedora:rawhide
-    options: --cap-add all --security-opt seccomp=unconfined --privileged
 
 jobs:
   - job: Test
@@ -16,21 +15,24 @@ jobs:
       vmImage: 'Ubuntu-16.04'
     strategy:
       matrix:
-        2.1-fedora-30:
-          containerResource: fedora-30
+        2.1-fedora-32:
+          containerResource: fedora-32
           DOTNET_VERSION: 2.1
-          options: --cap-add all --security-opt seccomp=unconfined --privileged
+        2.1-fedora-33:
+          containerResource: fedora-33
+          DOTNET_VERSION: 2.1
         2.1-fedora-rawhide:
           containerResource: fedora-rawhide
           DOTNET_VERSION: 2.1
-          options: --cap-add all --security-opt seccomp=unconfined --privileged
-        2.2-fedora-30:
-          containerResource: fedora-30
-          DOTNET_VERSION: 2.2
-        2.2-fedora-rawhide:
+        3.1-fedora-32:
+          containerResource: fedora-32
+          DOTNET_VERSION: 3.1
+        3.1-fedora-33:
+          containerResource: fedora-33
+          DOTNET_VERSION: 3.1
+        3.1-fedora-rawhide:
           containerResource: fedora-rawhide
-          DOTNET_VERSION: 2.2
-          options: --cap-add all --security-opt seccomp=unconfined --privileged
+          DOTNET_VERSION: 3.1
 
     container: $[ variables['containerResource'] ]
 
@@ -39,14 +41,27 @@ jobs:
         set -euo pipefail
         set -x
         cat /etc/os-release
-        sudo dnf install 'dnf-command(copr)' -y
-        sudo dnf copr enable @dotnet-sig/dotnet -y
-        sudo dnf install git python3 dotnet-sdk-${DOTNET_VERSION} -y
-        mkdir dotnet-regular-tests
-        mv $(ls * -d | grep -v dotnet-regular-tests) dotnet-regular-tests
-        git clone https://github.com/redhat-developer/dotnet-bunny
-        cd dotnet-bunny
-        mv ../dotnet-regular-tests .
-        sudo dnf install $(grep "^Dependencies: " dotnet-regular-tests/README.md | sed "s/Dependencies: //") -y
-        ./run-tests.py ${DOTNET_VERSION} -v
-        cat logfile.log
+        if grep Fedora /etc/os-release && [[ "${DOTNET_VERSION}" == "2.1" ]]; then
+          sudo dnf install 'dnf-command(copr)' -y
+          sudo dnf copr enable @dotnet-sig/dotnet -y
+        fi
+        sudo dnf install git python3 dotnet-sdk-${DOTNET_VERSION} wget $(grep "^Dependencies: " README.md | sed "s/Dependencies: //") -y
+        wget -q https://github.com/redhat-developer/dotnet-bunny/releases/latest/download/turkey-x86_64 -O turkey && chmod +x ./turkey
+        ./turkey --version
+        ### HACK
+        rm -rf debugging-sos-lldb* createdump-aspnet # debugging/coredumps via ptrace don't work in these locked down contianers
+        pushd hardened-binaries
+        set +e
+        ./test.sh
+        set -e
+        popd
+        mkdir -p logs/
+        ./turkey -v -l logs/
+      displayName: Run tests using turkey
+
+    - task: PublishTestResults@2
+      inputs:
+        failTaskOnFailedTests: true
+        testResultsFiles: '**/results.xml'
+        searchFolder: logs/
+      condition: always()


### PR DESCRIPTION
Update Fedora versions to 32, 33 and Rawhide. Fedora 30 is already EOL and Fedora 31 will be soon. Fedora 32 also includes .NET Core 3.1 in its default repositories.

.NET Core 2.2 and 3.0 are also EOL. Only 2.1 and 3.1 are fully supported right now.

Also save and publish test run results.

Everything should now be passing: https://dev.azure.com/omajid/omajid/_build/results?buildId=167&view=results

Test result example: https://dev.azure.com/omajid/omajid/_build/results?buildId=167&view=ms.vss-test-web.build-test-results-tab