### PR TITLE
Fix up xunit-smoketest to work with current test runner

### DIFF
--- a/xunit-smoketest/test.json
+++ b/xunit-smoketest/test.json
@@ -5,5 +5,9 @@
   "version": "2.1",
   "versionSpecific": false,
   "type": "bash",
-  "cleanup": true
+  "cleanup": true,
+  "ignoredRIDs":
+  [
+
+  ]
 }

--- a/xunit-smoketest/xunit-smoketest.csproj
+++ b/xunit-smoketest/xunit-smoketest.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>


### PR DESCRIPTION
There are two inconsistencies between what this test does and what the test runner expects:

- The test runner only patches up `netcoreappX.Y` TargetFramework entries in the csproj file.

- The test runner requires a `ignoredRIDs` element in the json. 

Fix these up so the test runs on top of the current runner.

Longer term, both these issues should be fixed in the runner. For example https://github.com/redhat-developer/dotnet-bunny/pull/41.

cc @RheaAyase @tmds 