### PR TITLE
Extend omnisharp test to cover more project types

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ jobs:
     timeout-minutes: 30
 
     strategy:
+      fail-fast: false
       matrix:
         container_image:
           - fedora:34

--- a/omnisharp/test.sh
+++ b/omnisharp/test.sh
@@ -18,30 +18,35 @@ pushd omnisharp
 tar xf "../omnisharp-${runtime_id}.tar.gz"
 popd
 
-mkdir hello
-pushd hello
-dotnet new console
-popd
+for project in blazorserver blazorwasm classlib console mstest mvc nunit web webapp webapi worker xunit ; do
 
-./omnisharp/run -s "$(readlink -f hello)" > omnisharp.log &
-omnisharp_pid=$!
+    mkdir hello-$project
+    pushd hello-$project
+    dotnet new $project
+    popd
 
-sleep 5
+    ./omnisharp/run -s "$(readlink -f hello-$project)" > omnisharp.log &
 
-pkill -P $$
+    sleep 5
 
-# Omnisharp spawns off a number of processes. They all include the
-# current directory as a process argument, so use that to identify and
-# kill them.
-kill $(ps aux | grep "$(pwd)" | grep -v 'grep' | awk '{ print $2 }')
+    pkill -P $$
 
-cat omnisharp.log
+    # Omnisharp spawns off a number of processes. They all include the
+    # current directory as a process argument, so use that to identify and
+    # kill them.
+    pgrep -f "$(pwd)"
 
-if grep ERROR omnisharp.log; then
-    echo "test failed"
-    exit 1
-else
-    echo "OK"
-fi
+    kill "$(pgrep -f "$(pwd)")"
+
+    cat omnisharp.log
+
+    if grep ERROR omnisharp.log; then
+        echo "test failed"
+        exit 1
+    else
+        echo "OK"
+    fi
+
+done
 
 popd


### PR DESCRIPTION
Omnisharp needs separate tasks/dlls for separate project types. Testing with just a `console` project is not sufficient to verify that all project types work. We need to test with each project type that we care about to make sure it works.

See https://github.com/dotnet/source-build/issues/2006 for more information.