### PR TITLE
Disable debugging-sos test

### DIFF
--- a/debugging-sos-lldb-via-core/test.json
+++ b/debugging-sos-lldb-via-core/test.json
@@ -1,6 +1,6 @@
 {
   "name": "debugging-sos-lldb-via-core",
-  "enabled": true,
+  "enabled": false,
   "requiresSdk": true,
   "version": "3.0",
   "versionSpecific": false,


### PR DESCRIPTION
This test has been failing for a while: https://github.com/dotnet/diagnostics/issues/1907

It hasn't been fixed upstream and we are still shipping things, so lets disable this test for now. 