### PR TITLE
Disable cgroup test on .NET Core 2.1

### DIFF
--- a/cgroup-limit/test.json
+++ b/cgroup-limit/test.json
@@ -2,7 +2,7 @@
   "name": "cgroup-limit",
   "enabled": true,
   "requiresSdk": true,
-  "version": "2.1",
+  "version": "3.0",
   "versionSpecific": false,
   "type": "bash",
   "cleanup": true,


### PR DESCRIPTION
GC.GetGCMemoryInfo was introduced with 3.0:
https://github.com/dotnet/coreclr/pull/23779

This method is missing in 2.1. So 2.1 fails to build this code with this
error:

    Program.cs(9,30): error CS0117: 'GC' does not contain a definition
    for 'GetGCMemoryInfo' [cgroup-limit/cgroup-limit.csproj]

The docs say that this method is available on 5.0 or later:
https://docs.microsoft.com/en-us/dotnet/api/system.gc.getgcmemoryinfo?view=net-5.0
but the docs are wrong since this code compiles on 3.1.