### PR TITLE
Show cgroup system information

### DIFF
--- a/cgroup-limit/test.sh
+++ b/cgroup-limit/test.sh
@@ -4,6 +4,10 @@ set -euo pipefail
 
 set -x
 
+cat /proc/self/mountinfo
+
+cat /proc/self/cgroup
+
 dotnet publish
 
 SYSTEMD_RUN="systemd-run"


### PR DESCRIPTION
That will help us figure out what cgroup system the test runner is using. That's useful to know because .NET Core 3.1 doesn't fully support cgroupv2.