### PR TITLE
Restrict cgroup-limit test to .NET 5 and later

### DIFF
--- a/cgroup-limit/test.json
+++ b/cgroup-limit/test.json
@@ -2,7 +2,7 @@
   "name": "cgroup-limit",
   "enabled": true,
   "requiresSdk": true,
-  "version": "3.0",
+  "version": "5.0",
   "versionSpecific": false,
   "type": "bash",
   "cleanup": true,


### PR DESCRIPTION
A number of test environments like Fedora are using cgroup v2, which is not supported with .NET Core 3.1.

Until we fix the support in .NET Core 3.1, we should disable this test.

This will, unfortunately, stop testing .NET Core 3.1's cgroup support even on environments using cgroup v1. Alternatively, we could block this test on Fedora, but that will stop testing .NET 5 on Fedora (where this test works and passes) as well.

What do you think, @tmds, @RheaAyase ?