### PR TITLE
Don't test cgroup support with .NET Core 3.1 on cgroup v2

### DIFF
--- a/cgroup-limit/test.sh
+++ b/cgroup-limit/test.sh
@@ -8,6 +8,11 @@ cat /proc/self/mountinfo
 
 cat /proc/self/cgroup
 
+if [[ "$(stat -f -c "%T" /sys/fs/cgroup)" == "cgroup2fs" ]] && [[ $(dotnet --version) == "3."* ]]; then
+    echo "cgroup v2 is not fully supported on .NET Core 3.x. Skipping."
+    exit 0
+fi
+
 dotnet publish
 
 SYSTEMD_RUN="systemd-run"


### PR DESCRIPTION
.NET Core 3.1 didn't support cgroup v2, so it's known not to work. It should still work with cgroup v1. Later versions of .NET (eg, .NET 5) should work in both cgroup v1 and v2.