### PR TITLE
Check offline framework-dependent deployment

### DIFF
--- a/fdd-publish-5.0/Program.cs
+++ b/fdd-publish-5.0/Program.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace fdd_publish
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            Console.WriteLine("Hello World!");
+        }
+    }
+}

--- a/fdd-publish-5.0/fdd-publish.csproj
+++ b/fdd-publish-5.0/fdd-publish.csproj
@@ -1,0 +1,6 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp5.0</TargetFramework>
+  </PropertyGroup>
+</Project>

--- a/fdd-publish-5.0/nuget.config
+++ b/fdd-publish-5.0/nuget.config
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+  </packageSources>
+</configuration>

--- a/fdd-publish-5.0/test.json
+++ b/fdd-publish-5.0/test.json
@@ -1,0 +1,13 @@
+{
+	"name": "fdd-publish-5.0",
+	"enabled": true,
+	"requiresSdk": true,
+	"version": "5.0",
+	"versionSpecific": true,
+	"type": "bash",
+	"cleanup": true,
+	"ignoredRIDs":[
+  
+	]
+  }
+  

--- a/fdd-publish-5.0/test.sh
+++ b/fdd-publish-5.0/test.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/bash
+
+set +x
+
+dotnet publish


### PR DESCRIPTION
I've tried to add the test to check the FDD deployment. Currently, there is a test just for 5.0, I guess I need to make a separate test case for 3.1 as well and can't reuse it (from what I've seen in other tests in the repository)?