### PR TITLE
Exclude system-libunwind test for RHEL 9

### DIFF
--- a/system-libunwind/test.json
+++ b/system-libunwind/test.json
@@ -8,6 +8,7 @@
   "cleanup": true,
   "ignoredRIDs":[
     "fedora-arm64",
-    "rhel8"
+    "rhel8",
+    "rhel9"
   ]
 }


### PR DESCRIPTION
RHEL 9 (and CentOS Stream 9) don't have a system copy of libunwind, similar to RHEL 8. So this test is wrong for that environment.