### PR TITLE
Revert "More thorough man page test"

### DIFF
--- a/man-pages/test.sh
+++ b/man-pages/test.sh
@@ -2,23 +2,17 @@
 
 set -euo pipefail
 
-helpPages=$(dotnet --help | grep -A 999 'SDK commands' | grep '^  ' | awk '{ print $1 }')
+helpPages=$(dotnet --help | grep -A 999 'SDK commands' | grep -E -B 999 'Common options|Additional commands' | awk 'NR>1 {print $1}' | head -n-2)
 manPages=$(rpm -qd $(rpm -qa | grep 'dotnet') | grep 'man1/dotnet-')
 
-failed=0
-for page in $helpPages; do
-    if echo "$manPages" | grep "dotnet-$page"; then
-        true
-    else
-        echo "error: Man page for dotnet-$page not found: FAIL"
-        failed=1
-    fi
+for page in $helpPages;
+do
+  echo "$manPages" | grep "dotnet-$page"
+  if [ $? -eq 1 ]; then
+    echo "Man page for dotnet-$page not found: FAIL"
+    exit 1
+  fi
 done
 
-if [[ $failed == 0 ]]; then
-    echo "All the man pages were found: PASS"
-else
-    echo "FAIL: some man pages are missing"
-fi
+echo "All the man pages were found: PASS"
 
-exit $failed


### PR DESCRIPTION
Reverts redhat-developer/dotnet-regular-tests#161

This test fails on all already-released versions. We shouldn't merge this without fixing them first.