### PR TITLE
Update version-apis test for .NET 6

### DIFF
--- a/version-apis/VersionTest.cs
+++ b/version-apis/VersionTest.cs
@@ -13,7 +13,7 @@ namespace DotNetCoreVersionApis
         {
             var version = Environment.Version;
             Console.WriteLine($"Environment.Version: {version}");
-            Assert.InRange(version.Major, 3, 5);
+            Assert.InRange(version.Major, 3, 6);
         }
 
         [Fact]
@@ -45,7 +45,7 @@ namespace DotNetCoreVersionApis
 
             bool okay = Version.TryParse(plainVersion, out Version parsedVersion);
             Assert.True(okay);
-            Assert.InRange(parsedVersion.Major, 3, 5);
+            Assert.InRange(parsedVersion.Major, 3, 6);
 
             var commitId = versionParts[1];
             Regex commitRegex = new Regex("[0-9a-fA-F]{40}");


### PR DESCRIPTION
It only knows about .NET versions until 5, so tell it about 6 as well.