### PR TITLE
man-pages should tell us which man pages were missing

### DIFF
--- a/man-pages/test.sh
+++ b/man-pages/test.sh
@@ -5,14 +5,20 @@ set -euo pipefail
 helpPages=$(dotnet --help | grep -A 999 'SDK commands' | grep -E -B 999 'Common options|Additional commands' | awk 'NR>1 {print $1}' | head -n-2)
 manPages=$(rpm -qd $(rpm -qa | grep 'dotnet') | grep 'man1/dotnet-')
 
-for page in $helpPages;
-do
-  echo "$manPages" | grep "dotnet-$page"
-  if [ $? -eq 1 ]; then
-    echo "Man page for dotnet-$page not found: FAIL"
-    exit 1
-  fi
+failed=0
+for page in $helpPages; do
+    if echo "$manPages" | grep "dotnet-$page"; then
+        true
+    else
+        echo "error: Man page for dotnet-$page not found: FAIL"
+        failed=1
+    fi
 done
 
-echo "All the man pages were found: PASS"
+if [[ $failed == 0 ]]; then
+    echo "All the man pages were found: PASS"
+else
+    echo "FAIL: some man pages are missing"
+fi
 
+exit $failed


### PR DESCRIPTION
The test can currently fail silently. Also, show all the errors on the run instead of failing on the first error.

This is another attempt at #161, but hopefully that causes no regressions. Notably, compared to #161, we are *not* testing that man pages exist for bundled tools (`dotnet devcerts`, `dotnet fsi`, `dotnet user-secrets`, `dotnet watch`, and so on).