### PR TITLE
Make workload test work on arm64/s390x as well

### DIFF
--- a/workload/test.sh
+++ b/workload/test.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 set -x
 
-WORKLOAD="wasm-tools"
+WORKLOAD="macos"
 
 dotnet workload install "$WORKLOAD"
 echo "PASS: workload install."


### PR DESCRIPTION
The `wasm-tools` workload is only available on x64 (aka x86_64). So this test fails on arm64 and s390x.

The `macos` workload seems to be available for all architectures. So use that instead so this test will work everywhere.

cc @tmds @BahaVv