### PR TITLE
Use the -s option in strace instead of --string-limit

### DIFF
--- a/telemetry-is-off-by-default/test.sh
+++ b/telemetry-is-off-by-default/test.sh
@@ -20,9 +20,9 @@ rm -rf HelloWeb
 
 mkdir HelloWeb
 pushd HelloWeb
-strace --string-limit 512 -e network -fo ../new.log dotnet new web
-strace --string-limit 512 -e network -fo ../restore.log dotnet restore "${no_server[@]}"
-strace --string-limit 512 -e network -fo ../build.log dotnet build -c Release  "${no_server[@]}"
+strace -s 512 -e network -fo ../new.log dotnet new web
+strace -s 512 -e network -fo ../restore.log dotnet restore "${no_server[@]}"
+strace -s 512 -e network -fo ../build.log dotnet build -c Release  "${no_server[@]}"
 popd
 rm -rf HelloWeb
 


### PR DESCRIPTION
Some older versions of strace dont support the --string-limit option, but
do support -s to mean the same thing.