### PR TITLE
Check dotnet/sdk/$VERSION/Sdks/$NAME/Sdk/Sdk.props exists

### DIFF
--- a/sdks-are-available/test.sh
+++ b/sdks-are-available/test.sh
@@ -28,7 +28,7 @@ for expected in "${expected_sdks[@]}"; do
     found=false
 
     for sdk in "${sdks[@]}"; do
-        if [[ "$(basename "$sdk")" == "$expected" ]]; then
+        if [[ "$(basename "$sdk")" == "$expected" ]] && [[ -f "${sdk}/Sdk/Sdk.props" ]] ; then
             found=true
         fi
     done


### PR DESCRIPTION
That's the main factor for identifying a directory as an SDK, apparently! It also makes the test correctly fail with the bug we ran into.