### PR TITLE
Fix file counting in managed-symbols-available

### DIFF
--- a/managed-symbols-available/test.sh
+++ b/managed-symbols-available/test.sh
@@ -12,7 +12,9 @@ IFS='.' read -ra VERSION <<< "$1"
 if [[ ${VERSION[0]} -ge 6 ]]; then
     echo "We are not supposed to be shipping symbol files starting with .NET 6"
 
-    if find "${framework_dir}" -name '*.pdb'; then
+    find "${framework_dir}" -name '*.pdb' || true
+
+    if [[ "$(find "${framework_dir}" -name '*.pdb' -printf '.' | wc -c)" -gt 0 ]] ; then
         echo "error: Found some pdb file."
         exit 1
     fi


### PR DESCRIPTION
`find` always returns an exit code of 0, even if no files matched. So let's be more explicit about counting pdb files here.