### PR TITLE
Initial Alpine support

### DIFF
--- a/apphost-framework-lookup/test.sh
+++ b/apphost-framework-lookup/test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if [ -f /etc/profile ]; then
   source /etc/profile

--- a/aspnet-same-runtime-version-2x/test.sh
+++ b/aspnet-same-runtime-version-2x/test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 

--- a/aspnet-same-runtime-version/test.sh
+++ b/aspnet-same-runtime-version/test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 

--- a/aspnetpatch-21/test.sh
+++ b/aspnetpatch-21/test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 set -x

--- a/assemblies-valid/AssembliesValid.cs
+++ b/assemblies-valid/AssembliesValid.cs
@@ -44,7 +44,7 @@ namespace AssembliesValid
         public void ValidateAssemblies()
         {
             string dotnetPath = null;
-            int exitCode = RunProcessAndGetOutput(new string[] { "bash", "-c", "\"command", "-v", "dotnet\"" }, out dotnetPath);
+            int exitCode = RunProcessAndGetOutput(new string[] { "bash", "-c", "command -v dotnet" }, out dotnetPath);
             if (exitCode != 0)
             {
                 Console.Error.WriteLine("'dotnet' command not found");
@@ -120,8 +120,11 @@ namespace AssembliesValid
         static int RunProcessAndGetOutput(string[] processAndArguments, out string standardOutput)
         {
             ProcessStartInfo startInfo = new ProcessStartInfo();
-            startInfo.FileName = processAndArguments[0];
-            startInfo.Arguments = string.Join(" ", processAndArguments.Skip(1));
+            startInfo.FileName =  processAndArguments[0];
+            foreach (string arg in processAndArguments.Skip(1))
+            {
+                startInfo.ArgumentList.Add(arg);
+            }
             startInfo.RedirectStandardOutput = true;
 
             using (Process p = Process.Start(startInfo))

--- a/assemblies-valid/AssembliesValid.cs
+++ b/assemblies-valid/AssembliesValid.cs
@@ -44,7 +44,7 @@ namespace AssembliesValid
         public void ValidateAssemblies()
         {
             string dotnetPath = null;
-            int exitCode = RunProcessAndGetOutput(new string[] { "command", "-v", "dotnet" }, out dotnetPath);
+            int exitCode = RunProcessAndGetOutput(new string[] { "bash", "-c", "\"command", "-v", "dotnet\"" }, out dotnetPath);
             if (exitCode != 0)
             {
                 Console.Error.WriteLine("'dotnet' command not found");
@@ -91,8 +91,8 @@ namespace AssembliesValid
                         if (hasMethods && !hasAot)
                         {
 #if NET6_0_OR_GREATER
-                            // s390x doesn't have aot support, and that's okay for now
-                            if (architecture != Architecture.S390x)
+                            // s390x (and arm) doesn't have aot support, and that's okay for now
+                            if (architecture != Architecture.S390x && architecture != Architecture.Arm)
                             {
 #endif
                                 valid = false;

--- a/bash-completion/get-completions.sh
+++ b/bash-completion/get-completions.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/usr/bin/env bash
 
 get_completion_function_name_from_complete_output()
 {

--- a/bash-completion/test.sh
+++ b/bash-completion/test.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 

--- a/bundled-libunwind/test.sh
+++ b/bundled-libunwind/test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 

--- a/cgroup-limit/test.sh
+++ b/cgroup-limit/test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 
@@ -10,6 +10,12 @@ cat /proc/self/cgroup
 
 if [[ "$(stat -f -c "%T" /sys/fs/cgroup)" == "cgroup2fs" ]] && [[ $(dotnet --version) == "3."* ]]; then
     echo "cgroup v2 is not fully supported on .NET Core 3.x. Skipping."
+    exit 0
+fi
+
+
+if [ -z "$(command -v systemctl)" ]; then
+    echo "Environment does not use systemd"
     exit 0
 fi
 

--- a/commit-ids-in-binaries/test.sh
+++ b/commit-ids-in-binaries/test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # .NET Core native binaries (coreclr.so, System.Native.so) contain a
 # commit id as text somewhere in the binary. For example

--- a/createdump-aspnet/test.sh
+++ b/createdump-aspnet/test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Enable "unofficial bash strict mode"
 set -euo pipefail

--- a/curl-certificate-store/test.sh
+++ b/curl-certificate-store/test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 

--- a/debugging-sos-lldb-via-core-2x/test.sh
+++ b/debugging-sos-lldb-via-core-2x/test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Check whether coredumps produced by .NET Core can be used by sos
 # successfully. This test uses the built-in CoreCLR sos support, not

--- a/debugging-sos-lldb-via-core/test.sh
+++ b/debugging-sos-lldb-via-core/test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Check whether coredumps produced by .NET Core can be used by sos
 # successfully. This test uses the `dotnet sos` global tool.

--- a/distribution-packages/test.json
+++ b/distribution-packages/test.json
@@ -6,6 +6,7 @@
   "type": "bash",
   "cleanup": true,
   "ignoredRIDs":[
-    "rhel7"
+    "rhel7",
+    "linux-musl"
   ]
 }

--- a/distribution-packages/test.sh
+++ b/distribution-packages/test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 
@@ -7,6 +7,9 @@ runtime_version="$(dotnet --list-runtimes | head -1 | awk '{ print $2 }')"
 runtime_id=$(../runtime-id)
 # This might be the final/only netstandard version from now on
 netstandard_version=2.1
+
+# disabled for alpine
+[ -z "${runtime_id##alpine*}" ] && { echo Disabled for Alpine; exit 0; }
 
 ./test-standard-packages \
     "${runtime_id}" \

--- a/distribution-packages/test.sh
+++ b/distribution-packages/test.sh
@@ -8,9 +8,6 @@ runtime_id=$(../runtime-id)
 # This might be the final/only netstandard version from now on
 netstandard_version=2.1
 
-# disabled for alpine
-[ -z "${runtime_id##alpine*}" ] && { echo Disabled for Alpine; exit 0; }
-
 ./test-standard-packages \
     "${runtime_id}" \
     "${runtime_version}" "${runtime_version}" \

--- a/dotnet-info-commit-ids/test.sh
+++ b/dotnet-info-commit-ids/test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # unofficial bash strict mode
 set -euo pipefail

--- a/extract-bundle-dir/test.sh
+++ b/extract-bundle-dir/test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # The profile file sets DOTNET_BUNDLE_EXTRACT_BASE_DIR to avoid multi-user issues.
 # see: https://bugzilla.redhat.com/show_bug.cgi?id=1752350.

--- a/fdd-no-nuget/test.sh
+++ b/fdd-no-nuget/test.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/usr/bin/env bash
 
 set +x
 

--- a/file-permissions/test.sh
+++ b/file-permissions/test.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 IFS=$'\n\t'

--- a/hardened-binaries/test.sh
+++ b/hardened-binaries/test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 IFS=$'\n\t'
@@ -8,7 +8,7 @@ echo ".NET Core base directory: $root"
 
 # TODO handle more architectures can just x86-64
 
-file_list=$(find "$root/" -type f -exec file {} \; | grep -E 'ELF 64-bit [LM]SB' | cut -d: -f 1 | sort -u)
+file_list=$(find "$root/" -type f -exec file {} \; | grep -E 'ELF [[:digit:]][[:digit:]]-bit [LM]SB' | cut -d: -f 1 | sort -u)
 mapfile -t binaries <<< "$file_list"
 for binary in "${binaries[@]}"; do
     echo "$binary"

--- a/helloworld/test.sh
+++ b/helloworld/test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 

--- a/install-location/test.sh
+++ b/install-location/test.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 IFS=$'\n\t'

--- a/liblttng-ust_sys-sdt.h/test.sh
+++ b/liblttng-ust_sys-sdt.h/test.sh
@@ -6,7 +6,7 @@ set -x
 RUNTIME_ID=$(../runtime-id)
 set +e  # disable abort-on-error so we can have the pipeline below fail
 case $RUNTIME_ID in
-  alpine*)packageName=$(apk list dotnet*lttng-ust);;
+  alpine*)packageName="" ;;
   *)packageName=$(rpm -qa | grep 'dotnet.*lttng-ust');;
 esac
 set -e
@@ -16,22 +16,20 @@ if [[ -z "$packageName" ]]; then
   case $RUNTIME_ID in
     alpine*)
       packageName="lttng-ust"
-    ;;
+      ;;
     *)
       packageName=$(rpm -qa | grep 'lttng-ust')
-    ;;
+      ;;
   esac
 fi
 
-# If a dotnet-specific lttng package doesn't exist, we must be using
-# the normal system-wide lttng package.
 case $RUNTIME_ID in
   alpine*)
     filePath="/$(apk info -L "$packageName" | grep -E 'liblttng-ust.so.[01]$')"
-  ;;
+    ;;
   *)
     filePath=$(rpm -ql "$packageName" | grep -E 'liblttng-ust.so.[01]$')
-  ;;
+    ;;
 esac
 
 readelf -n "$filePath" | grep -F 'NT_STAPSDT (SystemTap probe descriptors)'

--- a/liblttng-ust_sys-sdt.h/test.sh
+++ b/liblttng-ust_sys-sdt.h/test.sh
@@ -1,22 +1,43 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 set -x
 
+RUNTIME_ID=$(../runtime-id)
 set +e  # disable abort-on-error so we can have the pipeline below fail
-packageName=$(rpm -qa | grep 'dotnet.*lttng-ust')
+case $RUNTIME_ID in
+  alpine*)packageName=$(apk list dotnet*lttng-ust);;
+  *)packageName=$(rpm -qa | grep 'dotnet.*lttng-ust');;
+esac
 set -e
 # If a dotnet-specific lttng package doesn't exist, we must be using
 # the normal system-wide lttng package.
 if [[ -z "$packageName" ]]; then
-  packageName=$(rpm -qa | grep 'lttng-ust')
+  case $RUNTIME_ID in
+    alpine*)
+      packageName="lttng-ust"
+    ;;
+    *)
+      packageName=$(rpm -qa | grep 'lttng-ust')
+    ;;
+  esac
 fi
 
-filePath=$(rpm -ql "$packageName" | grep -E 'liblttng-ust.so.[01]$')
+# If a dotnet-specific lttng package doesn't exist, we must be using
+# the normal system-wide lttng package.
+case $RUNTIME_ID in
+  alpine*)
+    filePath="/$(apk info -L "$packageName" | grep -E 'liblttng-ust.so.[01]$')"
+  ;;
+  *)
+    filePath=$(rpm -ql "$packageName" | grep -E 'liblttng-ust.so.[01]$')
+  ;;
+esac
+
 readelf -n "$filePath" | grep -F 'NT_STAPSDT (SystemTap probe descriptors)'
 
 if [[ $? -eq 1 ]]; then
-  echo "NO NT_STAPSDT were found in lttng-ust: FAL"
+  echo "NO NT_STAPSDT were found in lttng-ust: FAIL"
   exit 1
 fi
 

--- a/libuv-kestrel-sample-app-2x/test.sh
+++ b/libuv-kestrel-sample-app-2x/test.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 

--- a/lttng/test.sh
+++ b/lttng/test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 
@@ -49,8 +49,11 @@ wait $DOTNET_PID
 echo "== Ending lttng session"
 end_session
 
+CMD="$(command -v babeltrace || true)"
+[ -z "${CMD}" ] && CMD="$(command -v babeltrace2)"
+
 # Retrieve trace
-LTTNG_TRACE=$(babeltrace "$TRACE_FOLDER/ust/uid/$(id -u)/64-bit" | grep "vpid = $DOTNET_PID")
+LTTNG_TRACE=$($CMD "$TRACE_FOLDER/ust/uid/$(id -u)/64-bit" | grep "vpid = $DOTNET_PID")
 
 # Clean up
 remove_test_folder

--- a/man-pages/test.sh
+++ b/man-pages/test.sh
@@ -1,9 +1,14 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 
 helpPages=$(dotnet --help | grep -A 999 'SDK commands' | grep -E -B 999 'Common options|Additional commands' | awk 'NR>1 {print $1}' | head -n-2)
-manPages=$(rpm -qd $(rpm -qa | grep 'dotnet') | grep 'man1/dotnet-')
+
+RUNTIME_ID=$(../runtime-id)
+case $RUNTIME_ID in
+	alpine*)manPages=$(apk info -L dotnet-doc);;
+	*)manPages=$(rpm -qd $(rpm -qa | grep 'dotnet') | grep 'man1/dotnet-');;
+esac
 
 failed=0
 for page in $helpPages; do

--- a/managed-symbols-available/test.sh
+++ b/managed-symbols-available/test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Check that managed symbol files are available
 

--- a/omnisharp/test.json
+++ b/omnisharp/test.json
@@ -6,6 +6,7 @@
   "type": "bash",
   "cleanup": true,
   "ignoredRIDs":[
+    "linux-musl",
     "linux-s390x"
   ]
 }

--- a/omnisharp/test.sh
+++ b/omnisharp/test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 IFS=$'\n\t'
@@ -10,6 +10,9 @@ mkdir workdir
 pushd workdir
 
 runtime_id="$(../../runtime-id --portable)"
+
+# disabled for alpine
+[ -z "${runtime_id##*musl*}" ] && { echo No musl release of omnisharp, disabled; exit 0; }
 
 wget --no-verbose "https://github.com/OmniSharp/omnisharp-roslyn/releases/latest/download/omnisharp-${runtime_id}.tar.gz"
 

--- a/omnisharp/test.sh
+++ b/omnisharp/test.sh
@@ -11,9 +11,6 @@ pushd workdir
 
 runtime_id="$(../../runtime-id --portable)"
 
-# disabled for alpine
-[ -z "${runtime_id##*musl*}" ] && { echo No musl release of omnisharp, disabled; exit 0; }
-
 wget --no-verbose "https://github.com/OmniSharp/omnisharp-roslyn/releases/latest/download/omnisharp-${runtime_id}.tar.gz"
 
 mkdir omnisharp

--- a/openssl-alpn/test.sh
+++ b/openssl-alpn/test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Make sure .NET Core has linked to SSL_*_alpn_* functions from OpenSSL
 

--- a/publish-ready-to-run-linux/test.sh
+++ b/publish-ready-to-run-linux/test.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 set -x

--- a/publish-ready-to-run/test.sh
+++ b/publish-ready-to-run/test.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 set -x

--- a/restore-with-rid/test.sh
+++ b/restore-with-rid/test.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 set -x

--- a/runtime-id
+++ b/runtime-id
@@ -38,11 +38,14 @@ while [[ $# -gt 0 ]]; do
 done
 
 if [[ ${portable_rid} == 1 ]]; then
-    echo "linux-${arch}"
+    case "${ID}" in
+        alpine)echo "linux-musl-${arch}" ;;
+        *) echo "linux-${arch}" ;;
+    esac
 else
     case "${ID}" in
         # Remove the RHEL minor version
-        rhel) rid_version=${VERSION_ID%.*} ;;
+        rhel|alpine|rocky) rid_version=${VERSION_ID%.*} ;;
 
         *) rid_version=${VERSION_ID} ;;
     esac

--- a/runtime-id
+++ b/runtime-id
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This is a script called by multiple tests to find the runtime id of
 # the current platform.
@@ -38,14 +38,15 @@ while [[ $# -gt 0 ]]; do
 done
 
 if [[ ${portable_rid} == 1 ]]; then
-    case "${ID}" in
-        alpine)echo "linux-musl-${arch}" ;;
-        *) echo "linux-${arch}" ;;
-    esac
+    if (ldd --version 2>&1 || true) | grep -q musl ; then
+        echo "linux-musl-${arch}"
+    else
+        echo "linux-${arch}"
+    fi
 else
     case "${ID}" in
-        # Remove the RHEL minor version
-        rhel|alpine|rocky) rid_version=${VERSION_ID%.*} ;;
+        # Remove the minor version
+        alpine|ol|rhel|rocky) rid_version=${VERSION_ID%.*} ;;
 
         *) rid_version=${VERSION_ID} ;;
     esac

--- a/sdks-are-available/test.sh
+++ b/sdks-are-available/test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 IFS=$'\n\t'

--- a/system-libcurl/test.sh
+++ b/system-libcurl/test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 

--- a/system-libunwind/test.sh
+++ b/system-libunwind/test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 

--- a/system-openssl/test.sh
+++ b/system-openssl/test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Make sure .NET has ldd-visible links to OpenSSL. We prefer that over
 # using OpenSSL via dlopen (which is more likely to fail at runtime).

--- a/targeting-packs-bad-files/test.sh
+++ b/targeting-packs-bad-files/test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 

--- a/telemetry-is-off-by-default/test-telemetry-tcpdump.sh
+++ b/telemetry-is-off-by-default/test-telemetry-tcpdump.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This test is *NOT* executed by default.
 

--- a/telemetry-is-off-by-default/test.sh
+++ b/telemetry-is-off-by-default/test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This test ensures telemetry is not being sent for (some) commands by
 # checking that no network connections are being made when not

--- a/template-test/test.sh
+++ b/template-test/test.sh
@@ -165,7 +165,7 @@ dotnet help > /dev/null 2>/dev/null
 
 readarray -t allAutoTemplates < <(
     dotnet new --list |
-        sed '0,/^------/d' |
+        sed '0,/^--*/d' |
         awk -F '  +' ' { print $2 }' |
         sed 's/,/\n/' |
         sed -e '/^ *$/d' |

--- a/template-test/test.sh
+++ b/template-test/test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # this file tests templates created by
 # dotnet new <template>

--- a/tool-dev-certs/test.sh
+++ b/tool-dev-certs/test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if [ -f /etc/profile ]; then
   source /etc/profile

--- a/use-apphost-from-sdk/test.sh
+++ b/use-apphost-from-sdk/test.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 IFS=$'\n\t'

--- a/use-current-runtime/test.sh
+++ b/use-current-runtime/test.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 

--- a/workload/test.sh
+++ b/workload/test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 

--- a/xunit-smoketest/test.sh
+++ b/xunit-smoketest/test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 


### PR DESCRIPTION
## Description
Alpine support

## Modifications
* replaced all non-portable shebangs with `#!/usr/bin/env bash`
* `assemblies-valid`: explicitely call bash for built-in command `command` when looking for dotnet binary
* `cgroup-limit`: disable when init system not systemd
* `distribution-packages`: disabled for Alpine as test uses `rpm`
* `iblttng-ust_sys-sdt.h`: adapted for use with `apk`
* `lttng`: look for `babeltrace2` if cannot find `babeltrace`
* `man-page`: adapted for use with `apk`
* `omnisharp`: disabled for Alpine as omnisharp has no linux-musl release
* `runtime-id`: adapted to parse Alpine runtime-id correctly

## Problematic tests
* `liblttng-ust_sys-sdt.h` / `lttng` : test works: no 'NT_STAPSDT` on Alpine's `lttng-ust` package + `lttng-ust` 2.13 breaks tracing (see https://github.com/dotnet/runtime/issues/57784)
* `workload` / `createdump-aspnet`: permission issue, `Inadequate permissions. Run the command with elevated privileges` 
* `publish-ready-to-run` / `publish-ready-to-run-linux` (on `arm` / `arm64` only, fixed by https://github.com/dotnet/runtime/pull/66814)
* `omnisharp`: no `linux-musl` release (see https://github.com/OmniSharp/omnisharp-roslyn/issues/2366)

## Related PRs / Issues
https://github.com/dotnet/installer/pull/13074

Made as part of Alpine Linux dotnet6 packaging project, see https://github.com/dotnet/source-build/issues/2782