### PR TITLE
List available workloads in workload test

### DIFF
--- a/workload/test.sh
+++ b/workload/test.sh
@@ -19,6 +19,8 @@ fi
 mkdir -p "$(pwd)/workload-temp/"
 export TMPDIR="$(pwd)/workload-temp/"
 
+dotnet workload search
+
 WORKLOAD="macos"
 
 dotnet workload install "$WORKLOAD"


### PR DESCRIPTION
The list of workload seems to vary based on platforms and architectures;
it's useful for debugging if we know what workloads are actually
available.