### PR TITLE
Deal with upstream workload changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,5 +12,5 @@ $ git clone https://github.com/redhat-developer/dotnet-bunny && cd dotnet-bunny 
 
 ### Dependencies
 
-Dependencies: babeltrace bash-completion findutils jq lttng-tools npm strace /usr/bin/free /usr/bin/lldb /usr/bin/readelf /usr/bin/file which
+Dependencies: babeltrace bash-completion findutils jq lttng-tools npm strace /usr/bin/free /usr/bin/lldb /usr/bin/readelf /usr/bin/file which /usr/bin/su
 

--- a/workload/test.json
+++ b/workload/test.json
@@ -5,5 +5,8 @@
   "versionSpecific": false,
   "type": "bash",
   "cleanup": true,
-  "ignoredRIDs":[ ]
+  "ignoredRIDs": [
+    "linux-arm64",
+    "linux-s390x"
+  ]
 }

--- a/workload/test.sh
+++ b/workload/test.sh
@@ -21,7 +21,7 @@ export TMPDIR="$(pwd)/workload-temp/"
 
 dotnet workload search
 
-WORKLOAD="macos"
+WORKLOAD="wasm-tools"
 
 dotnet workload install "$WORKLOAD"
 echo "PASS: workload install."


### PR DESCRIPTION
The macos workload has disappeared and can no longer be installed on
linux-x64. Asking around, seems like this is intentional?

linux-x64 will support wasm-tools, and those don't seem to be avialable
for other architectures. In fact, linux-arm64 has *no* available
workloads!