### PR TITLE
Remove blazorwasm from 3.1 templates

### DIFF
--- a/template-test/test.sh
+++ b/template-test/test.sh
@@ -80,7 +80,6 @@ dotnet5Templates=(
 dotnet3Templates=(
     angular
     blazorserver
-    blazorwasm
     classlib
     console
     gitignore


### PR DESCRIPTION
Not sure how it got in there: it's not present in the 3.1 releases from
Microsoft or source-build.