### PR TITLE
Extend OmniSharp tests to cover more versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,17 +18,22 @@ jobs:
       fail-fast: false
       matrix:
         container_image:
-          - registry.fedoraproject.org/fedora:34
           - registry.fedoraproject.org/fedora:35
+          - registry.fedoraproject.org/fedora:36
+          - registry.fedoraproject.org/fedora:37
           - registry.fedoraproject.org/fedora:rawhide
           - registry.access.redhat.com/ubi8
+          - registry.access.redhat.com/ubi9
         dotnet_version:
           - "3.1"
-          - "5.0"
           - "6.0"
         exclude:
+          - container_image: registry.fedoraproject.org/fedora:37
+            dotnet_version: "3.1"
           - container_image: registry.fedoraproject.org/fedora:rawhide
-            dotnet_version: "5.0"
+            dotnet_version: "3.1"
+          - container_image: registry.access.redhat.com/ubi9
+            dotnet_version: "3.1"
 
     container:
       image: ${{ matrix.container_image }}
@@ -69,6 +74,10 @@ jobs:
           ### HACK: UBI 8 is missing strace and bash-completion packages for tests
           if [[ ${{ matrix.container_image }} == *ubi8* ]] ; then
               rm -rf telemetry-is-off-by-default bash-completion
+          fi
+          ### HACK: UBI 9 is missing strace package for tests
+          if [[ ${{ matrix.container_image }} == *ubi9* ]] ; then
+              rm -rf telemetry-is-off-by-default
           fi
 
           dotnet turkey/Turkey.dll -v --timeout 600

--- a/omnisharp/test.sh
+++ b/omnisharp/test.sh
@@ -11,61 +11,82 @@ pushd workdir
 
 runtime_id="$(../../runtime-id --portable)"
 
-wget --no-verbose "https://github.com/OmniSharp/omnisharp-roslyn/releases/latest/download/omnisharp-${runtime_id}.tar.gz"
+omnisharp_urls=(
+    "https://github.com/OmniSharp/omnisharp-roslyn/releases/latest/download/omnisharp-${runtime_id}-net6.0.tar.gz"
+    "https://github.com/OmniSharp/omnisharp-roslyn/releases/download/v1.38.2/omnisharp-${runtime_id}.tar.gz"
+    "https://github.com/OmniSharp/omnisharp-roslyn/releases/download/v1.37.17/omnisharp-${runtime_id}.tar.gz"
+)
 
-mkdir omnisharp
-pushd omnisharp
-tar xf "../omnisharp-${runtime_id}.tar.gz"
-popd
+IFS='.' read -ra version_split <<< "$1"
 
-if [[ "$(ldd omnisharp/bin/mono 2>&1 >/dev/null | wc -l )" -gt 0 ]]; then
-    echo "This version of mono is incompatible. Falling back."
-    rm -r "omnisharp-${runtime_id}.tar.gz"
-    rm -r omnisharp
+function run_omnisharp_against_projects
+{
+    for project in blazorserver blazorwasm classlib console mstest mvc nunit web webapp webapi worker xunit ; do
 
-    wget --no-verbose "https://github.com/OmniSharp/omnisharp-roslyn/releases/download/v1.37.17/omnisharp-${runtime_id}.tar.gz"
+        rm -rf hello-$project
+        mkdir hello-$project
+        pushd hello-$project
+        dotnet new $project
+        popd
+
+        "$@" "$(readlink -f hello-$project)" > omnisharp.log &
+
+        sleep 5
+
+        pkill -P $$
+
+        # Omnisharp can spawn off a number of processes. If so, they
+        # will include the current directory as a process argument, so
+        # use that to identify and kill them.
+        pgrep -if omnisharp
+        mapfile -t to_kill < <(pgrep -f "$(pwd)")
+        if [[ "${#to_kill[@]}" -gt 0 ]] ; then
+            kill "${to_kill[@]}"
+        fi
+
+        cat omnisharp.log
+
+        if grep ERROR omnisharp.log; then
+            echo "test failed"
+            exit 1
+        else
+            echo "OK"
+        fi
+    done
+}
+
+for download_url in "${omnisharp_urls[@]}"; do
+    tarball=$(basename "$download_url")
+    rm -f "$tarball"
+    rm -rf omnisharp
+    wget --no-verbose "$download_url"
+
+    if [[ "${version_split[0]}" -lt 6 ]] && [[ "$download_url" = *"net6.0"* ]]; then
+        echo "Skipping .NET 6 build of OmniSharp on .NET ${version_split[0]}.${version_split[1]}"
+        continue
+    fi
 
     mkdir omnisharp
     pushd omnisharp
-    tar xf "../omnisharp-${runtime_id}.tar.gz"
-    popd
-
-    if [[ "$(ldd omnisharp/bin/mono 2>&1 >/dev/null | wc -l )" -gt 0 ]]; then
-        echo "error: Can't find a compatible version of mono. Please update the test."
-        exit 100
-    fi
-fi
-
-
-for project in blazorserver blazorwasm classlib console mstest mvc nunit web webapp webapi worker xunit ; do
-
-    mkdir hello-$project
-    pushd hello-$project
-    dotnet new $project
-    popd
-
-    ./omnisharp/run -s "$(readlink -f hello-$project)" > omnisharp.log &
-
-    sleep 5
-
-    pkill -P $$
-
-    # Omnisharp spawns off a number of processes. They all include the
-    # current directory as a process argument, so use that to identify and
-    # kill them.
-    pgrep -f "$(pwd)"
-
-    kill "$(pgrep -f "$(pwd)")"
-
-    cat omnisharp.log
-
-    if grep ERROR omnisharp.log; then
-        echo "test failed"
-        exit 1
+    tar xf "../$tarball"
+    if [ -f "omnisharp/bin/mono" ]; then
+        if [[ "$(ldd omnisharp/bin/mono 2>&1 >/dev/null | wc -l )" -gt 0 ]]; then
+            echo "This version of mono is incompatible. Skipping."
+            continue
+        fi
+        run_omnisharp_against_projects omnisharp/bin/mono
+    elif [ -f "run" ]; then
+        if [[ "$(ldd bin/mono 2>&1 >/dev/null | wc -l )" -gt 0 ]]; then
+            echo "This version of mono is incompatible. Skipping."
+            continue
+        fi
+        run_omnisharp_against_projects ./run
+    elif [ -f "OmniSharp" ]; then
+        run_omnisharp_against_projects ./OmniSharp
     else
-        echo "OK"
+        echo "Unable to find Omnisharp"
+        find . | sort -u
+        false
     fi
-
+    popd
 done
-
-popd


### PR DESCRIPTION
OmniSharp upstream has been making a number of changes, and we should
extend this test to stay compatible with it. In particular, there a
number of different OmniSharp versions that were released recently and
all of them work differently in terms of dependencies they need and the
command line to use.

The latest releases (1.39 on) come in two flavours: A .NET 6 build and a
Mono-based-build. The Mono version requires an installation of mono on
the system to work. So download and run the .NET 6 version explicitly.

The slightly-older releases (1.38) include a bundled Mono. It needs to
use the ./run script to run. This mono is built against a recent version
of glibc that may not work well on some OS's.

The even-older releases (1.37) use a bundled Mono and need a script at a
different location to run.

Test all these variants of OmniSharp to ensure they all work, as much as
possible..