### PR TITLE
Stay in current directory if switching user in workload test

### DIFF
--- a/workload/test.sh
+++ b/workload/test.sh
@@ -4,19 +4,21 @@ set -euo pipefail
 
 set -x
 
-# This test *must* be run as non-root for it to have any meaning. So, force it
-# to re-run itself under a non-root user if it's accidentally run as root.
-if [[ $(id -u) == "0" ]]; then
-    id testrunner || useradd testrunner
-    su - testrunner -c "$(readlink -f "$0")" "$@"
-    exit
-fi
-
 # In some environments, such as Github Actions, /tmp/ is strange and
 # basically reserved for root only. So lets use another directory as
 # /tmp/ for this test for the temporary data. Main workload
 # installation is still to the user's home.
 mkdir -p "$(pwd)/workload-temp/"
+
+# This test *must* be run as non-root for it to have any meaning. So, force it
+# to re-run itself under a non-root user if it's accidentally run as root.
+if [[ $(id -u) == "0" ]]; then
+    id testrunner || useradd testrunner
+    chmod ugo+rw "$(pwd)/workload-temp/"
+    su testrunner -c "$(readlink -f "$0")" "$@"
+    exit
+fi
+
 export TMPDIR="$(pwd)/workload-temp/"
 
 dotnet workload search


### PR DESCRIPTION
`su -` switches to another user's environment completely, including out of the current directory. That means we lose access to NuGet.Config files that are placed in the current directory tree. And that means we lose access to any needed and configured nuget repositories. 