### PR TITLE
Handle multiple lttng-ust packages better

### DIFF
--- a/liblttng-ust_sys-sdt.h/test.sh
+++ b/liblttng-ust_sys-sdt.h/test.sh
@@ -4,31 +4,32 @@ set -euo pipefail
 set -x
 
 RUNTIME_ID=$(../runtime-id)
+declare -a packageNames
 set +e  # disable abort-on-error so we can have the pipeline below fail
 case $RUNTIME_ID in
-  alpine*)packageName="" ;;
-  *)packageName=$(rpm -qa | grep 'dotnet.*lttng-ust');;
+  alpine*) ;;
+  *) mapfile -t packageNames < <(rpm -qa | grep 'dotnet.*lttng-ust') ;;
 esac
 set -e
 # If a dotnet-specific lttng package doesn't exist, we must be using
 # the normal system-wide lttng package.
-if [[ -z "$packageName" ]]; then
+if [[ "${#packageNames[@]}" == 0 ]]; then
   case $RUNTIME_ID in
     alpine*)
-      packageName="lttng-ust"
+      packageNames=("lttng-ust")
       ;;
     *)
-      packageName=$(rpm -qa | grep 'lttng-ust')
+      mapfile -t packageNames < <(rpm -qa | grep 'lttng-ust')
       ;;
   esac
 fi
 
 case $RUNTIME_ID in
   alpine*)
-    filePath="/$(apk info -L "$packageName" | grep -E 'liblttng-ust.so.[01]$')"
+    filePath="/$(apk info -L "${packageNames[@]}" | grep -E 'liblttng-ust.so.[01]$')"
     ;;
   *)
-    filePath=$(rpm -ql "$packageName" | grep -E 'liblttng-ust.so.[01]$')
+    filePath=$(rpm -ql "${packageNames[@]}" | grep -E 'liblttng-ust.so.[01]$')
     ;;
 esac
 


### PR DESCRIPTION
On a system with multiple lttng packages installed (eg lttng-ust and lttng-ust-devel), this would use multiple names as a single argument, which would result in things failing. If multiple packages are installed, treat them as separate packages.