### PR TITLE
Get tests to mostly pass against .NET 7 RC 1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,9 @@ jobs:
         dotnet_version:
           - "3.1"
           - "6.0"
+        include:
+          - container_image: quay.io/centos/centos:stream9-development
+            dotnet_version: "7.0"
         exclude:
           - container_image: registry.fedoraproject.org/fedora:37
             dotnet_version: "3.1"

--- a/createdump-aspnet/test.sh
+++ b/createdump-aspnet/test.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 
 set -x
 
-IFS='.' read -ra VERSION_SPLIT <<< "$1"
+IFS='.-' read -ra VERSION_SPLIT <<< "$1"
 
 version=${VERSION_SPLIT[0]}.${VERSION_SPLIT[1]}
 

--- a/distribution-packages/test.sh
+++ b/distribution-packages/test.sh
@@ -2,8 +2,8 @@
 
 set -euo pipefail
 
-sdk_version="$(dotnet --version)"
-runtime_version="$(dotnet --list-runtimes | head -1 | awk '{ print $2 }')"
+sdk_version="$(dotnet --version | cut -d- -f1)"
+runtime_version="$(dotnet --list-runtimes | head -1 | awk '{ print $2 }' | cut -d- -f1)"
 runtime_id=$(../runtime-id)
 # This might be the final/only netstandard version from now on
 netstandard_version=2.1

--- a/dotnet-directory
+++ b/dotnet-directory
@@ -36,7 +36,7 @@ if [[ -z ${version} ]]; then
 fi
 
 declare -a versions
-IFS='.' read -ra versions <<< "${version}"
+IFS='.-' read -ra versions <<< "${version}"
 dotnet_dir=$(dirname "$(readlink -f "$(command -v dotnet)")")
 framework_dirs=( "${dotnet_dir}/shared/Microsoft.NETCore.App/${versions[0]}.${versions[1]}"* )
 framework_dir="${framework_dirs[0]}"

--- a/lttng/test.json
+++ b/lttng/test.json
@@ -7,6 +7,7 @@
   "type": "bash",
   "cleanup": true,
   "ignoredRIDs":[
+    "centos",
     "rhel"
   ]
 }

--- a/managed-symbols-available/test.sh
+++ b/managed-symbols-available/test.sh
@@ -7,7 +7,7 @@ IFS=$'\n\t'
 
 framework_dir=$(../dotnet-directory --framework "$1")
 
-IFS='.' read -ra VERSION <<< "$1"
+IFS='.-' read -ra VERSION <<< "$1"
 
 if [[ ${VERSION[0]} -ge 6 ]]; then
     echo "We are not supposed to be shipping symbol files starting with .NET 6"

--- a/no-source-files-in-nuget/test.sh
+++ b/no-source-files-in-nuget/test.sh
@@ -5,7 +5,7 @@ set -x
 
 rm -rf project.json
 
-IFS='.' read -ra VERSION <<< "$1"
+IFS='.-' read -ra VERSION <<< "$1"
 NEW_CMD="new console --force"
 if [[ "${VERSION[0]}" = "1" ]]; then
   NEW_CMD="new -t console"

--- a/omnisharp/test.sh
+++ b/omnisharp/test.sh
@@ -17,7 +17,7 @@ omnisharp_urls=(
     "https://github.com/OmniSharp/omnisharp-roslyn/releases/download/v1.37.17/omnisharp-${runtime_id}.tar.gz"
 )
 
-IFS='.' read -ra version_split <<< "$1"
+IFS='.-' read -ra version_split <<< "$1"
 
 function run_omnisharp_against_projects
 {

--- a/sdks-are-available/test.sh
+++ b/sdks-are-available/test.sh
@@ -14,7 +14,7 @@ expected_sdks=(
     Microsoft.NET.Sdk.Worker
 )
 
-IFS='.' read -ra dotnet_versions <<< "$1"
+IFS='.-' read -ra dotnet_versions <<< "$1"
 
 declare -a sdk_dir
 sdk_dir=( "$(../dotnet-directory --home "$1")"/sdk/"${dotnet_versions[0]}"* )

--- a/system-libunwind/test.json
+++ b/system-libunwind/test.json
@@ -7,6 +7,8 @@
   "type": "bash",
   "cleanup": true,
   "ignoredRIDs":[
+    "centos.8",
+    "centos.9",
     "fedora-arm64",
     "fedora-s390x",
     "rhel.8",

--- a/telemetry-is-off-by-default/test.sh
+++ b/telemetry-is-off-by-default/test.sh
@@ -13,14 +13,14 @@ set -x
 
 no_server=("/nodeReuse:false" "/p:UseSharedCompilation=false" "/p:UseRazorBuildServer=false")
 
-IFS='.' read -ra VERSION_SPLIT <<< "$1"
+IFS='.-' read -ra VERSION_SPLIT <<< "$1"
 DOTNET_MAJOR="${VERSION_SPLIT[0]}"
 
 rm -rf HelloWeb
 
 mkdir HelloWeb
 pushd HelloWeb
-strace -s 512 -e network -fo ../new.log dotnet new web
+strace -s 512 -e network -fo ../new.log dotnet new web --no-restore
 strace -s 512 -e network -fo ../restore.log dotnet restore "${no_server[@]}"
 strace -s 512 -e network -fo ../build.log dotnet build -c Release  "${no_server[@]}"
 popd

--- a/template-test/test.sh
+++ b/template-test/test.sh
@@ -10,6 +10,42 @@ set -euo pipefail
 # If additional templates are found via `dotnet new --list`, this test
 # will fail unless they are added here.
 
+dotnet7Templates=(
+    angular
+    blazorserver
+    blazorserver-empty
+    blazorwasm
+    blazorwasm-empty
+    classlib
+    console
+    editorconfig
+    gitignore
+    globaljson
+    grpc
+    mstest
+    mvc
+    nugetconfig
+    nunit
+    nunit-test
+    page
+    proto
+    razor
+    razorclasslib
+    razorcomponent
+    react
+    sln
+    solution
+    tool-manifest
+    viewimports
+    viewstart
+    web
+    webapi
+    webapp
+    webconfig
+    worker
+    xunit
+)
+
 dotnet6Templates=(
     angular
     blazorserver
@@ -124,7 +160,9 @@ dotnet3Templates=(
 templateActions=\
 "angular build
 blazorserver build
+blazorserver-empty build
 blazorwasm build
+blazorwasm-empty build
 classlib build
 console run
 mstest test
@@ -189,9 +227,11 @@ for template in "${allAutoTemplates[@]}"; do
     fi
 done
 
-IFS='.' read -ra VERSION_SPLIT <<< "$1"
+IFS='.-' read -ra VERSION_SPLIT <<< "$1"
 declare -a allTemplates
-if [[ ${VERSION_SPLIT[0]} == "6" ]]; then
+if [[ ${VERSION_SPLIT[0]} == "7" ]]; then
+    allTemplates=( "${dotnet7Templates[@]}" )
+elif [[ ${VERSION_SPLIT[0]} == "6" ]]; then
     allTemplates=( "${dotnet6Templates[@]}" )
 elif [[ ${VERSION_SPLIT[0]} == "5" ]]; then
     allTemplates=( "${dotnet5Templates[@]}" )

--- a/tool-dev-certs/test.sh
+++ b/tool-dev-certs/test.sh
@@ -9,7 +9,7 @@ fi
 set -euo pipefail
 set -x
 
-IFS='.' read -ra VERSION_SPLIT <<< "$1"
+IFS='.-' read -ra VERSION_SPLIT <<< "$1"
 VERSION="${VERSION_SPLIT[0]}.${VERSION_SPLIT[1]}"
 
 # it's okay if the tool is already installed

--- a/version-apis/VersionTest.cs
+++ b/version-apis/VersionTest.cs
@@ -8,12 +8,13 @@ namespace DotNetCoreVersionApis
 {
     public class VersionTest
     {
+        public static readonly int MAX_DOTNET_MAJOR_VERSION = 7;
         [Fact]
         public void EnvironmentVersion()
         {
             var version = Environment.Version;
             Console.WriteLine($"Environment.Version: {version}");
-            Assert.InRange(version.Major, 3, 6);
+            Assert.InRange(version.Major, 3, MAX_DOTNET_MAJOR_VERSION);
         }
 
         [Fact]
@@ -45,7 +46,7 @@ namespace DotNetCoreVersionApis
 
             bool okay = Version.TryParse(plainVersion, out Version parsedVersion);
             Assert.True(okay);
-            Assert.InRange(parsedVersion.Major, 3, 6);
+            Assert.InRange(parsedVersion.Major, 3, MAX_DOTNET_MAJOR_VERSION);
 
             var commitId = versionParts[1];
             Regex commitRegex = new Regex("[0-9a-fA-F]{40}");


### PR DESCRIPTION
- When parsing versions, split on both `.` and `-` to get all the version parts correctly, including any `-preview.` and `-rc.n` parts.

- In release-version-sane, ignore any prereleases such as -rc and -preview. Treat them as ordinary versions without the suffixes. So `7.0.0-rc.1.buildid` becomes `7.0.0`.

- Use `dotnet new web --no-restore` in the strace test to make sure build servers don't get started.

- Add templates for .NET 7.

- Allow 7.0 as a major .NET version in version-apis.

There's one known failures after these changes: `omnisharp`, which doesn't seem to support .NET 7.

See: #208 