### PR TITLE
Skip OmniSharp on .NET 7

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,5 +12,5 @@ $ git clone https://github.com/redhat-developer/dotnet-bunny && cd dotnet-bunny 
 
 ### Dependencies
 
-Dependencies: babeltrace bash-completion findutils jq lttng-tools npm strace /usr/bin/free /usr/bin/lldb /usr/bin/readelf /usr/bin/file which /usr/bin/su
+Dependencies: babeltrace bash-completion findutils gcc jq libstdc++ lttng-tools npm strace /usr/bin/free /usr/bin/lldb /usr/bin/readelf /usr/bin/file which /usr/bin/su
 

--- a/omnisharp/test.sh
+++ b/omnisharp/test.sh
@@ -19,6 +19,11 @@ omnisharp_urls=(
 
 IFS='.-' read -ra version_split <<< "$1"
 
+if [[ "${version_split[0]}" == "7" ]]; then
+    echo "warning: OmniSharp is known to be broken for .NET 7. Skipping."
+    exit 0
+fi
+
 function run_omnisharp_against_projects
 {
     for project in blazorserver blazorwasm classlib console mstest mvc nunit web webapp webapi worker xunit ; do


### PR DESCRIPTION
The recent .NET 6-based releases of OmniSharp aren't compatible with the current releases of .NET 7

- We can use omnisharp.json to enable using preview SDKs, which gets OmniSharp started.

- OmniSharp shows this error when trying to load .NET 7 RC 2 projects:

  ```
  Version 7.0.100-rc.2.22511.1 of the .NET SDK requires at least version 17.3.0 of MSBuild. The current available version of MSBuild is 17.1.1.12406. Change the .NET SDK specified in global.json to an older version that requires the MSBuild version currently available.
  ```

This approach is not the greatest; it shows a PASS in the results instead of a SKIP. But we don't have a way to skip specific versions when running the test through test.json.