### PR TITLE
Added ppc64le in cases which needs to skipped and also in runtime-id

### DIFF
--- a/apphost-framework-lookup/test.json
+++ b/apphost-framework-lookup/test.json
@@ -7,7 +7,8 @@
   "type": "bash",
   "cleanup": true,
   "ignoredRIDs":[
-    "linux-s390x"
+    "linux-s390x",
+    "linux-ppc64le"
   ]
 }
 

--- a/assemblies-valid/AssembliesValid.cs
+++ b/assemblies-valid/AssembliesValid.cs
@@ -90,15 +90,18 @@ namespace AssembliesValid
                         }
                         if (hasMethods && !hasAot)
                         {
+                            // 32-bit arm doesn't have AOT and niehter do s390x and ppc64le (which use mono). That's okay for now.
+                            if (architecture != Architecture.Arm
+#if NET7_0_OR_GREATER
+                                && architecture != Architecture.Ppc64le
+#endif
 #if NET6_0_OR_GREATER
-                            // s390x (and arm) doesn't have aot support, and that's okay for now
-                            if (architecture != Architecture.S390x && architecture != Architecture.Arm && architecture != Architecture.Ppc64le)
+                                && architecture != Architecture.S390x
+#endif
+                                )
                             {
-#endif
                                 valid = false;
-#if NET6_0_OR_GREATER
                             }
-#endif
                         }
 
                         if (valid)
@@ -146,11 +149,13 @@ namespace AssembliesValid
                     return Machine.Arm;
                 case Architecture.Arm64:
                     return Machine.Arm64;
+#if NET7_0_OR_GREATER
+                case Architecture.Ppc64le;
+                    return Machine.Unknown;
+#endif
 #if NET6_0_OR_GREATER
                 case Architecture.S390x:
                     return Machine.Unknown;
-		case Architecture.Ppc64le;
-		    return Machine.Unknown;
 #endif
                 case Architecture.X64:
                     return Machine.Amd64;

--- a/assemblies-valid/AssembliesValid.cs
+++ b/assemblies-valid/AssembliesValid.cs
@@ -92,7 +92,7 @@ namespace AssembliesValid
                         {
 #if NET6_0_OR_GREATER
                             // s390x (and arm) doesn't have aot support, and that's okay for now
-                            if (architecture != Architecture.S390x && architecture != Architecture.Arm)
+                            if (architecture != Architecture.S390x && architecture != Architecture.Arm && architecture != Architecture.Ppc64le)
                             {
 #endif
                                 valid = false;
@@ -149,6 +149,8 @@ namespace AssembliesValid
 #if NET6_0_OR_GREATER
                 case Architecture.S390x:
                     return Machine.Unknown;
+		case Architecture.Ppc64le;
+		    return Machine.Unknown;
 #endif
                 case Architecture.X64:
                     return Machine.Amd64;

--- a/assemblies-valid/AssembliesValid.cs
+++ b/assemblies-valid/AssembliesValid.cs
@@ -150,7 +150,7 @@ namespace AssembliesValid
                 case Architecture.Arm64:
                     return Machine.Arm64;
 #if NET7_0_OR_GREATER
-                case Architecture.Ppc64le;
+                case Architecture.Ppc64le:
                     return Machine.Unknown;
 #endif
 #if NET6_0_OR_GREATER

--- a/cgroup-limit/test.json
+++ b/cgroup-limit/test.json
@@ -7,6 +7,7 @@
   "type": "bash",
   "cleanup": true,
   "ignoredRIDs":[
-    "linux-s390x"
+    "linux-s390x",
+    "linux-ppc64le"
   ]
 }

--- a/createdump-aspnet/test.json
+++ b/createdump-aspnet/test.json
@@ -7,6 +7,7 @@
   "type": "bash",
   "cleanup": true,
   "ignoredRIDs":[
-    "linux-s390x"
+    "linux-s390x",
+    "linux-ppc64le"
   ]
 }

--- a/liblttng-ust_sys-sdt.h/test.json
+++ b/liblttng-ust_sys-sdt.h/test.json
@@ -7,6 +7,7 @@
   "type": "bash",
   "cleanup": true,
   "ignoredRIDs":[
-    "linux-s390x"
+    "linux-s390x",
+    "linux-ppc64le"
   ]
 }

--- a/nativeaot/test.json
+++ b/nativeaot/test.json
@@ -7,6 +7,7 @@
   "type": "bash",
   "cleanup": true,
   "ignoredRIDs":[
-    "linux-s390x"
+    "linux-s390x",
+    "linux-ppc64le"
   ]
 }

--- a/omnisharp/test.json
+++ b/omnisharp/test.json
@@ -7,6 +7,7 @@
   "cleanup": true,
   "ignoredRIDs":[
     "linux-musl",
-    "linux-s390x"
+    "linux-s390x",
+    "linux-ppc64le"
   ]
 }

--- a/publish-ready-to-run-linux/test.json
+++ b/publish-ready-to-run-linux/test.json
@@ -7,6 +7,7 @@
   "type": "bash",
   "cleanup": true,
   "ignoredRIDs":[
-    "linux-s390x"
+    "linux-s390x",
+    "linux-ppc64le"
   ]
 }

--- a/publish-ready-to-run/test.json
+++ b/publish-ready-to-run/test.json
@@ -7,6 +7,7 @@
   "type": "bash",
   "cleanup": true,
   "ignoredRIDs":[
-    "linux-s390x"
+    "linux-s390x",
+    "linux-ppc64le"
   ]
 }

--- a/restore-with-rid/test.json
+++ b/restore-with-rid/test.json
@@ -7,6 +7,7 @@
   "type": "bash",
   "cleanup": true,
   "ignoredRIDs":[
-    "linux-s390x"
+    "linux-s390x",
+    "linux-ppc64le"
   ]
 }

--- a/runtime-id
+++ b/runtime-id
@@ -22,6 +22,7 @@ archmap=(
     ["i386"]="x86"
     ["x86_64"]="x64"
     ["s390x"]="s390x"
+    ["ppc64le"]="ppc64le"
 )
 
 arch=${archmap["$(uname -m)"]}

--- a/system-libunwind/test.json
+++ b/system-libunwind/test.json
@@ -11,6 +11,7 @@
     "centos.9",
     "fedora-arm64",
     "fedora-s390x",
+    "fedora-ppc64le",
     "rhel.8",
     "rhel.9"
   ]

--- a/template-test/test.sh
+++ b/template-test/test.sh
@@ -298,11 +298,11 @@ function testTemplate {
 
     if [ "${action}" = "new" ] ; then
         true # no additional action
-    elif [[ ( $(uname -m) == "s390x" ) && ( "${templateName}" == "angular" ) ]]; then
+    elif [[ ( $(uname -m) == "s390x" ||  $(uname -m) == "ppc64le" ) && ( "${templateName}" == "angular" ) ]]; then
         # angular needs the node module fsevents, which is not supported on s390x
         true
     elif [ "${action}" = "build" ] || [ "${action}" = "run" ] || [ "${action}" = "test" ] ; then
-        if [[ ( $(uname -m) == "s390x" ) && ( "${templateName}" == "xunit" || "${templateName}" == "nunit" || "${templateName}" == "mstest" ) ]]; then
+        if [[ ( $(uname -m) == "s390x" ||  $(uname -m) == "ppc64le" ) && ( "${templateName}" == "xunit" || "${templateName}" == "nunit" || "${templateName}" == "mstest" ) ]]; then
             # xunit/nunit/mstest need a package version fix for s390x;
             # the default templates are known to be broken out of the
             # box

--- a/use-current-runtime/test.json
+++ b/use-current-runtime/test.json
@@ -7,6 +7,7 @@
   "type": "bash",
   "cleanup": true,
   "ignoredRIDs":[
-    "linux-s390x"
+    "linux-s390x",
+    "linux-ppc64le"
   ]
 }

--- a/workload/test.json
+++ b/workload/test.json
@@ -7,6 +7,7 @@
   "cleanup": true,
   "ignoredRIDs": [
     "linux-arm64",
-    "linux-s390x"
+    "linux-s390x",
+    "linux-ppc64le"
   ]
 }


### PR DESCRIPTION
Added ppc64le architecture in ignoredRIDs for cases which requires nuget packages that are not shipped to the customer referring to s390x.

Also added in runtime-id, to run test on ppc64le

