### PR TITLE
Update Microsoft.NET.Test.SDK for ppc64le support

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,6 +2,6 @@
   <PropertyGroup>
     <XunitVersion>2.4.1</XunitVersion>
     <XunitRunnerVisualStudioVersion>2.4.3</XunitRunnerVisualStudioVersion>
-    <MicrosoftNetTestSdkVersion>17.0.0</MicrosoftNetTestSdkVersion>
+    <MicrosoftNetTestSdkVersion>17.5.0-preview-20221024-01</MicrosoftNetTestSdkVersion>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Only recent nightly builds of Microsoft.NET.Test.SDK support ppc64le. These very recent builds are only available via the development feeds (not on nuget.org), but the test runner already knows about them.