### PR TITLE
Enable cgroup-limit test for s390x and ppc64le 

### DIFF
--- a/cgroup-limit/cgroup-limit.csproj
+++ b/cgroup-limit/cgroup-limit.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/cgroup-limit/test.json
+++ b/cgroup-limit/test.json
@@ -7,7 +7,5 @@
   "type": "bash",
   "cleanup": true,
   "ignoredRIDs":[
-    "linux-s390x",
-    "linux-ppc64le"
   ]
 }

--- a/template-test/test.sh
+++ b/template-test/test.sh
@@ -302,11 +302,14 @@ function testTemplate {
         # angular needs the node module fsevents, which is not supported on s390x
         true
     elif [ "${action}" = "build" ] || [ "${action}" = "run" ] || [ "${action}" = "test" ] ; then
-        if [[ ( $(uname -m) == "s390x" ||  $(uname -m) == "ppc64le" ) && ( "${templateName}" == "xunit" || "${templateName}" == "nunit" || "${templateName}" == "mstest" ) ]]; then
+        if [[ ( $(uname -m) == "s390x" ) && ( "${templateName}" == "xunit" || "${templateName}" == "nunit" || "${templateName}" == "mstest" ) ]]; then
             # xunit/nunit/mstest need a package version fix for s390x;
             # the default templates are known to be broken out of the
             # box
             sed -i -E 's|(PackageReference Include="Microsoft.NET.Test.Sdk" Version=")16.11.0"|\117.0.0"|' ./*.csproj
+	elif [[ ( $(uname -m) == "ppc64le" ) && ( "${templateName}" == "xunit" || "${templateName}" == "nunit" || "${templateName}" == "mstest" ) ]]; then
+            # xunit/nunit/mstest need a package version fix for a version with enablement for ppc64le;
+            sed -i -E 's|(PackageReference Include="Microsoft.NET.Test.Sdk" Version=")17.3.2"|\117.5.0-preview-20221024-01"|' ./*.csproj
         fi
         if ! dotnet "${action}"; then
             failedTests=$((failedTests+1))


### PR DESCRIPTION
The https://github.com/dotnet/runtime/pull/77682 is a prerequisite to enabling the cgroup-limit test 