### PR TITLE
Update Microsoft.NET.Test.Sdk version to suppport ppc64le

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,6 +2,6 @@
   <PropertyGroup>
     <XunitVersion>2.4.1</XunitVersion>
     <XunitRunnerVisualStudioVersion>2.4.3</XunitRunnerVisualStudioVersion>
-    <MicrosoftNetTestSdkVersion>17.0.0</MicrosoftNetTestSdkVersion>
+    <MicrosoftNetTestSdkVersion>17.4.0</MicrosoftNetTestSdkVersion>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Older versions of the Microsoft.NET.Test.Sdk fail to work on ppc64le and throw a `System.NotSupportedException`.