### PR TITLE
Add support for cgroup test on s390x

### DIFF
--- a/cgroup-limit/test.json
+++ b/cgroup-limit/test.json
@@ -7,7 +7,6 @@
   "type": "bash",
   "cleanup": true,
   "ignoredRIDs":[
-    "linux-s390x",
     "linux-ppc64le"
   ]
 }

--- a/cgroup-limit/test.sh
+++ b/cgroup-limit/test.sh
@@ -13,6 +13,15 @@ if [[ "$(stat -f -c "%T" /sys/fs/cgroup)" == "cgroup2fs" ]] && [[ $(dotnet --ver
     exit 0
 fi
 
+# Enable "cgroup-limit" test on s390x on .NET 7.0 onwards
+if [ $(uname -m) == "s390x" ]; then
+  VERSION_STR="$(dotnet --version)"
+  VERSION_ID="$(echo "$(echo ${VERSION_STR} | cut -d"." -f1)")"
+  if [[ "$VERSION_ID" -lt "7" ]]; then
+    echo "On s390x, cgroup test is not supported on .NET 6.x. Its only supported from .NET 7.x onwards. Skipping."
+    exit 0
+  fi
+fi
 
 if [ -z "$(command -v systemctl)" ]; then
     echo "Environment does not use systemd"


### PR DESCRIPTION
Remove the s390x from unsupported architecture RID list

Enable "cgroup-limit" test on s390x on .NET 7.0 onwards

The feature support is provided from .NET 7.0 and beyond. This test should not run if the .NET release is 6.0 or earlier ones.