### PR TITLE
Disable debugging-via-dotnet-dump on mono-based architectures

### DIFF
--- a/debugging-via-dotnet-dump/test.json
+++ b/debugging-via-dotnet-dump/test.json
@@ -7,6 +7,8 @@
   "type": "bash",
   "cleanup": true,
   "ignoredRIDs":[
+    "linux-ppc64le",
+    "linux-s390x"
   ]
 }
 


### PR DESCRIPTION
We know dotnet-dump is broken on those.