### PR TITLE
Fix ehinfo command test in debugging-via-dotnet-dump

### DIFF
--- a/debugging-via-dotnet-dump/test.sh
+++ b/debugging-via-dotnet-dump/test.sh
@@ -387,7 +387,7 @@ grep -E '[1-9][0-9]* gc heaps' dump.out
 
 heading "ehinfo"
 dump-analyze 'name2ee *!System.String.ToString' > dump.out
-dump-analyze 'ehinfo' > dump.out
+cat dump.out
 mapfile -t to_string_method_descriptors < <(grep 'MethodDesc:' dump.out | awk '{print $2}')
 for desc in "${to_string_method_descriptors[@]}"; do
     dump-analyze "ehinfo ${desc}" > dump.out


### PR DESCRIPTION
The command needs a MethodDesc to work. The test was using name2ee to get a list of MethodDesc, saving it to a file, overwriting that file with something different, then trying to fetch MethodDescs from there.

This was even causing errors in older versions of the bash script.

Fix that by removing the simple `ehinfo` invocation, which doesn't even do anything or produce any useful output.