### PR TITLE
Exclude system-data-odbc on RHEL 7

### DIFF
--- a/system-data-odbc/test.json
+++ b/system-data-odbc/test.json
@@ -7,5 +7,6 @@
   "type": "bash",
   "cleanup": true,
   "ignoredRIDs":[
+    "rhel7"
   ]
 }

--- a/system-data-odbc/test.sh
+++ b/system-data-odbc/test.sh
@@ -27,7 +27,7 @@ function cleanup {
 PGDATA="$(pwd)/data"
 export PGDATA
 export PGHOST=localhost
-export PGPORT=$((1024 + "$RANDOM" ))
+export PGPORT=$((1024 + $RANDOM ))
 
 PGSOCKET="$(pwd)/socket"
 
@@ -38,6 +38,9 @@ trap cleanup EXIT ERR
 
 pg_ctl initdb
 pg_ctl start -o "-k $PGSOCKET"
+until pg_ctl status; do
+    sleep 1
+done
 
 psql template1 -c "CREATE DATABASE testdb;"
 psql testdb -c "CREATE TABLE test (ID INT PRIMARY KEY, NAME TEXT);"


### PR DESCRIPTION
The test uses postgres on RHEL 7 via the unixODBC driver. That driver on RHEL 7 appears to be buggy, since it tries to use the 32-bit libraries on a 64-bit machine. The odbc configuration defines a `Driver64` that ought to be used on the 64-bit machine, but that's not used. That looks like a RHEL bug in the unixODBC package, but at this time in RHEL 7's lifecycle I am not expecting it to get fixed.

Also fix some other bugs that came up when testing on RHEL 7:

- Allow testing on slower machines where postgres takes a few seconds to start.

- Don't quote variables in bash's arithmetic expressions.