### PR TITLE
Disable debugging-sos-lldb-via-core on s390x/ppc64le

### DIFF
--- a/debugging-sos-lldb-via-core/test.json
+++ b/debugging-sos-lldb-via-core/test.json
@@ -7,6 +7,8 @@
   "type": "bash",
   "cleanup": true,
   "ignoredRIDs":[
+    "linux-ppc64le",
+    "linux-s390x"
   ]
 }
 


### PR DESCRIPTION
Neither of these have createdump executables that are used to create the dumps.