### PR TITLE
Add skipWhen=ci for tests that are known to fail on a vmr ci build.

### DIFF
--- a/apphost-framework-lookup/test.json
+++ b/apphost-framework-lookup/test.json
@@ -6,6 +6,9 @@
   "versionSpecific": false,
   "type": "bash",
   "cleanup": true,
+  "skipWhen": [
+    "ci" // portable runtime packs not published
+  ],
   "ignoredRIDs":[
     "linux-s390x",
     "linux-ppc64le"

--- a/bash-completion/test.json
+++ b/bash-completion/test.json
@@ -6,6 +6,9 @@
   "versionSpecific": false,
   "type": "bash",
   "cleanup": true,
+  "skipWhen": [
+    "ci" // bash completion script not installed
+  ],
   "ignoredRIDs":[
   ]
 }

--- a/bundled-libunwind/test.json
+++ b/bundled-libunwind/test.json
@@ -6,6 +6,10 @@
   "versionSpecific": false,
   "type": "bash",
   "cleanup": true,
+  "skipWhen": [
+    "os=fedora,version=6", // .NET 6 on Fedora uses system libunwind.
+    "os=fedora,version=7"  // .NET 7 on Fedora uses system libunwind.
+  ],
   "ignoredRIDs":[
     "alpine",
     "fedora",

--- a/cgroup-limit/test.sh
+++ b/cgroup-limit/test.sh
@@ -28,7 +28,7 @@ if [ -z "$(command -v systemctl)" ]; then
     exit 0
 fi
 
-dotnet publish
+dotnet publish -c Release
 
 SYSTEMD_RUN="systemd-run"
 if [ "$UID" != "0" ]; then
@@ -41,7 +41,7 @@ if [ "$UID" != "0" ]; then
   fi
 fi
 
-mapfile -t DOTNET_LIMITS < <($SYSTEMD_RUN  -q --scope -p CPUQuota=100% -p MemoryLimit=100M bin/Debug/net*/cgroup-limit)
+mapfile -t DOTNET_LIMITS < <($SYSTEMD_RUN  -q --scope -p CPUQuota=100% -p MemoryLimit=100M bin/Release/net*/cgroup-limit)
 
 if [ "${DOTNET_LIMITS[0]}" == "Limits:" ] &&      # Application ran.
    [ "${DOTNET_LIMITS[1]}" == "1" ] &&            # Available processors is 1.

--- a/debugging-sos-lldb-via-core/test.sh
+++ b/debugging-sos-lldb-via-core/test.sh
@@ -3,9 +3,8 @@
 # Check whether coredumps produced by .NET Core can be used by sos
 # successfully. This test uses the `dotnet sos` global tool.
 
-if [ -f /etc/profile ]; then
-  source /etc/profile
-fi
+# Ensure global tools are on PATH.
+export PATH=~/.dotnet/tools:$PATH
 
 # Enable "unofficial strict mode" only after loading /etc/profile
 # because that usually contains lots of "errors".

--- a/debugging-via-dotnet-dump/test.json
+++ b/debugging-via-dotnet-dump/test.json
@@ -6,6 +6,9 @@
   "versionSpecific": false,
   "type": "bash",
   "cleanup": true,
+  "skipWhen": [
+    "version=8" // see https://github.com/redhat-developer/dotnet-regular-tests/issues/249
+  ],
   "ignoredRIDs":[
     "linux-ppc64le",
     "linux-s390x"

--- a/debugging-via-dotnet-dump/test.sh
+++ b/debugging-via-dotnet-dump/test.sh
@@ -3,9 +3,8 @@
 # Check whether dotnet-dump, and its subcommands like `ps`, `collect`
 # and `analyze` are working
 
-if [ -f /etc/profile ]; then
-  source /etc/profile
-fi
+# Ensure global tools are on PATH.
+export PATH=~/.dotnet/tools:$PATH
 
 # Enable "unofficial strict mode" only after loading /etc/profile
 # because that usually contains lots of "errors".

--- a/distribution-packages/test.json
+++ b/distribution-packages/test.json
@@ -5,6 +5,9 @@
   "versionSpecific": false,
   "type": "bash",
   "cleanup": true,
+  "skipWhen": [
+    "ci" // not packaged (tar.gz build)
+  ],
   "ignoredRIDs":[
     "rhel7",
     "linux-musl"

--- a/file-permissions/test.json
+++ b/file-permissions/test.json
@@ -6,6 +6,9 @@
   "versionSpecific": false,
   "type": "bash",
   "cleanup": true,
+  "skipWhen": [
+    "ci" // not packaged (tar.gz build)
+  ],
   "ignoredRIDs":[
 
   ]

--- a/man-pages/test.json
+++ b/man-pages/test.json
@@ -6,6 +6,9 @@
   "versionSpecific": false,
   "type": "bash",
   "cleanup": true,
+  "skipWhen": [
+    "ci" // man page not installed
+  ],
   "ignoredRIDs":[
   ]
 }

--- a/omnisharp/test.json
+++ b/omnisharp/test.json
@@ -5,6 +5,9 @@
   "versionSpecific": false,
   "type": "bash",
   "cleanup": true,
+  "skipWhen": [
+    "version=8" // see https://github.com/redhat-developer/dotnet-regular-tests/issues/250
+  ],
   "ignoredRIDs":[
     "linux-musl",
     "linux-s390x",

--- a/publish-ready-to-run-linux/test.json
+++ b/publish-ready-to-run-linux/test.json
@@ -6,6 +6,9 @@
   "versionSpecific": false,
   "type": "bash",
   "cleanup": true,
+  "skipWhen": [
+    "ci" // portable runtime/crossgen packs not published
+  ],
   "ignoredRIDs":[
     "linux-s390x",
     "linux-ppc64le"

--- a/publish-ready-to-run/test.json
+++ b/publish-ready-to-run/test.json
@@ -6,6 +6,9 @@
   "versionSpecific": false,
   "type": "bash",
   "cleanup": true,
+  "skipWhen": [
+    "ci" // portable runtime/crossgen packs not published
+  ],
   "ignoredRIDs":[
     "linux-s390x",
     "linux-ppc64le"

--- a/system-libunwind/test.json
+++ b/system-libunwind/test.json
@@ -6,6 +6,9 @@
   "versionSpecific": false,
   "type": "bash",
   "cleanup": true,
+  "skipWhen": [
+    "os=fedora,version=8" // .NET 8 on Fedora uses bundled libunwind.
+  ],
   "ignoredRIDs":[
     "centos.8",
     "centos.9",

--- a/targeting-packs-bad-files/test.json
+++ b/targeting-packs-bad-files/test.json
@@ -6,6 +6,9 @@
   "versionSpecific": false,
   "type": "bash",
   "cleanup": true,
+  "skipWhen": [
+    "version=8" // see https://github.com/redhat-developer/dotnet-regular-tests/issues/251
+  ],
   "ignoredRIDs":[
 
   ]

--- a/template-test/test.json
+++ b/template-test/test.json
@@ -6,6 +6,9 @@
   "versionSpecific": false,
   "type": "bash",
   "cleanup": true,
+  "skipWhen": [
+    "ci" // template packages not published
+  ],
   "ignoredRIDs":[
   ]
 }

--- a/use-current-runtime/test.json
+++ b/use-current-runtime/test.json
@@ -6,6 +6,9 @@
   "versionSpecific": false,
   "type": "bash",
   "cleanup": true,
+  "skipWhen": [
+    "ci" // portable runtime packs not published
+  ],
   "ignoredRIDs":[
     "linux-s390x",
     "linux-ppc64le"

--- a/version-apis/VersionTest.cs
+++ b/version-apis/VersionTest.cs
@@ -8,7 +8,7 @@ namespace DotNetCoreVersionApis
 {
     public class VersionTest
     {
-        public static readonly int MAX_DOTNET_MAJOR_VERSION = 7;
+        public static readonly int MAX_DOTNET_MAJOR_VERSION = 8;
         [Fact]
         public void EnvironmentVersion()
         {

--- a/workload/test.json
+++ b/workload/test.json
@@ -5,6 +5,9 @@
   "versionSpecific": false,
   "type": "bash",
   "cleanup": true,
+  "skipWhen": [
+    "ci" // workload packages not published
+  ],
   "ignoredRIDs": [
     "alpine", // see https://github.com/redhat-developer/dotnet-regular-tests/pull/222
     "linux-arm64",


### PR DESCRIPTION
Fixes https://github.com/redhat-developer/dotnet-regular-tests/issues/235.

@omajid ptal.