### PR TITLE
Add a test for file descriptor exhaustion

### DIFF
--- a/file-descriptor-exhaustion/NuGet.config
+++ b/file-descriptor-exhaustion/NuGet.config
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <!-- lots of nuget sources to make .NET try and access all of them, exhausting file descriptors -->
+    <add key="dotnet3.1" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet3.1/nuget/v3/index.json"/>
+    <add key="dotnet3.1-transport" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet3.1-transport/nuget/v3/index.json"/>
+    <add key="dotnet5" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet5/nuget/v3/index.json"/>
+    <add key="dotnet5-transport" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet5-transport/nuget/v3/index.json"/>
+    <add key="dotnet6" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6/nuget/v3/index.json"/>
+    <add key="dotnet6-transport" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6-transport/nuget/v3/index.json"/>
+    <add key="dotnet7" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet7/nuget/v3/index.json"/>
+    <add key="dotnet7-transport" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet7-transport/nuget/v3/index.json"/>
+    <add key="dotnet8" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet8/nuget/v3/index.json"/>
+    <add key="dotnet8-transport" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet8-transport/nuget/v3/index.json"/>
+    <add key="dotnet-eng" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json"/>
+    <add key="dotnet-experimental" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-experimental/nuget/v3/index.json"/>
+    <add key="dotnet-libraries" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-libraries/nuget/v3/index.json"/>
+    <add key="dotnet-libraries-transport" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-libraries-transport/nuget/v3/index.json"/>
+    <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json"/>
+    <add key="dotnet-public-local" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public%40local/nuget/v3/index.json"/>
+    <add key="dotnet-tools" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json"/>
+    <add key="dotnet-tools-transport" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools-transport/nuget/v3/index.json"/>
+    <add key="general-testing" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/general-testing/nuget/v3/index.json"/>
+    <add key="messagepack-csharp" value="https://pkgs.dev.azure.com/ils0086/messagepack-csharp/_packaging/messagepack-ci/nuget/v3/index.json"/>
+    <add key="myget-applicationinsights" value="https://www.myget.org/f/applicationinsights/api/v3/index.json"/>
+    <add key="myget-aspnet-contrib" value="https://www.myget.org/f/aspnet-contrib/api/v3/index.json"/>
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json"/>
+    <add key="test-tools" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/test-tools/nuget/v3/index.json"/>
+  </packageSources>
+</configuration>
+

--- a/file-descriptor-exhaustion/UnitTest1.cs
+++ b/file-descriptor-exhaustion/UnitTest1.cs
@@ -1,0 +1,15 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace FileDescriptorExhaustion;
+
+public class UnitTest1
+{
+    [Fact]
+    public static void True()
+    {
+        Assert.True(true);
+    }
+}

--- a/file-descriptor-exhaustion/file-descriptor-exhaustion.csproj
+++ b/file-descriptor-exhaustion/file-descriptor-exhaustion.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <TargetFramework>netcoreapp6.0</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+	<PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNetTestSdkVersion)" />
+	<PackageReference Include="xunit" Version="$(XunitVersion)" />
+	<PackageReference Include="xunit.runner.visualstudio" Version="$(XunitRunnerVisualStudioVersion)" />
+  </ItemGroup>
+
+</Project>

--- a/file-descriptor-exhaustion/test.json
+++ b/file-descriptor-exhaustion/test.json
@@ -1,0 +1,12 @@
+{
+  "name": "file-descriptor-exhaustion",
+  "enabled": true,
+  "requiresSdk": true,
+  "version": "8.0",
+  "versionSpecific": false,
+  "type": "xunit",
+  "cleanup": true,
+  "ignoredRIDs":[
+  ]
+}
+


### PR DESCRIPTION
The mono based runtimes (used on ppc64le/s390x) have a bug where the process has a low limit for file descriptors and then exhausts them quickly. More at https://github.com/dotnet/runtime/issues/82428. This was fixed for .NET 8

Add a check for that.