### PR TITLE
tools-in-path: skip on vmr-ci.

### DIFF
--- a/tools-in-path/test.json
+++ b/tools-in-path/test.json
@@ -5,6 +5,9 @@
   "versionSpecific": false,
   "type": "bash",
   "cleanup": true,
+  "skipWhen": [
+    "vmr-ci" // tools PATH not configured (tar.gz build)
+  ],
   "ignoredRIDs": [
   ]
 }


### PR DESCRIPTION
cc @omajid 