### PR TITLE
managed-symbols-available: skip on vmr-ci.

### DIFF
--- a/managed-symbols-available/test.json
+++ b/managed-symbols-available/test.json
@@ -6,6 +6,9 @@
   "versionSpecific": false,
   "type": "bash",
   "cleanup": true,
+  "skipWhen": [
+    "vmr-ci" // https://github.com/redhat-developer/dotnet-regular-tests/issues/267
+  ],
   "ignoredRIDs":[
   ]
 }


### PR DESCRIPTION
cc @omajid 