### PR TITLE
Add a test to make sure file descriptor limits are correct

### DIFF
--- a/limits/LimitsTest.cs
+++ b/limits/LimitsTest.cs
@@ -1,0 +1,41 @@
+using System.Diagnostics;
+using System.Globalization;
+using Xunit;
+
+namespace Limit;
+
+public class LimitsTest
+{
+    [Fact]
+    public void FileDescriptorLimitIsAtMax()
+    {
+        int softLimit = int.Parse(RunAndGetProcessOutput("ulimit", new List<string> { "-Sn" }), CultureInfo.InvariantCulture);
+        int hardLimit = int.Parse(RunAndGetProcessOutput("ulimit", new List<string> { "-Hn" }), CultureInfo.InvariantCulture);
+
+        Assert.Equal(hardLimit, softLimit, $"File descriptor soft limit ({softLimit}) should be the same as the hard limit ({hardLimit}).");
+    }
+
+    private static string RunAndGetProcessOutput(string name, List<string> args)
+    {
+        ProcessStartInfo psi = new()
+        {
+            FileName = name,
+            RedirectStandardOutput = true,
+        };
+        foreach (string arg in args)
+        {
+            psi.ArgumentList.Add(arg);
+        }
+
+        Process? p = Process.Start(psi);
+        if (p is not null)
+        {
+            p.WaitForExit();
+            return p.StandardOutput.ReadToEnd();
+        }
+        else
+        {
+            throw new InvalidOperationException();
+        }
+    }
+}

--- a/limits/limits.csproj
+++ b/limits/limits.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNetTestSdkVersion)" />
+    <PackageReference Include="xunit" Version="$(XunitVersion)" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitRunnerVisualStudioVersion)" />
+  </ItemGroup>
+
+</Project>

--- a/limits/test.json
+++ b/limits/test.json
@@ -1,0 +1,10 @@
+{
+  "name": "limits",
+  "enabled": true,
+  "requiresSdk": true,
+  "version": "8.0",
+  "versionSpecific": false,
+  "type": "xunit",
+  "cleanup": true,
+  "ignoredRIDs": []
+}


### PR DESCRIPTION
Some versions of the mono based runtimes (used on ppc64le/s390x) are know to have a bug where the process has a low limit for file descriptors and then exhausts them quickly. It's easy to run into this if you use many nuget sources, for example. More at dotnet/runtime#82428. This was fixed for .NET 8