### PR TITLE
Fix compilation error in limits test

### DIFF
--- a/limits/LimitsTest.cs
+++ b/limits/LimitsTest.cs
@@ -12,7 +12,7 @@ public class LimitsTest
         int softLimit = int.Parse(RunAndGetProcessOutput("ulimit", new List<string> { "-Sn" }), CultureInfo.InvariantCulture);
         int hardLimit = int.Parse(RunAndGetProcessOutput("ulimit", new List<string> { "-Hn" }), CultureInfo.InvariantCulture);
 
-        Assert.Equal(hardLimit, softLimit, $"File descriptor soft limit ({softLimit}) should be the same as the hard limit ({hardLimit}).");
+        Assert.True(hardLimit == softLimit, $"File descriptor soft limit ({softLimit}) should be the same as the hard limit ({hardLimit}).");
     }
 
     private static string RunAndGetProcessOutput(string name, List<string> args)


### PR DESCRIPTION
There's no overload for `Assert.Equal(int, int, message)`. See https://github.com/xunit/xunit/issues/350.