### PR TITLE
Update templates for .NET 8 Preview 6

### DIFF
--- a/template-test/test.sh
+++ b/template-test/test.sh
@@ -15,8 +15,6 @@ dotnet8Templates=(
     apicontroller
     angular
     blazor
-    blazorserver
-    blazorserver-empty
     blazorwasm
     blazorwasm-empty
     buildprops


### PR DESCRIPTION
The blazorserver and blazorserver-empty templates have been removed from Preview 6. Upstream PR: https://github.com/dotnet/aspnetcore/pull/48615. Update tests to work correctly against that.