### PR TITLE
debugging tests: skip on mono.

### DIFF
--- a/debugging-sos-lldb-via-core/test.json
+++ b/debugging-sos-lldb-via-core/test.json
@@ -6,9 +6,7 @@
   "versionSpecific": false,
   "type": "bash",
   "cleanup": true,
-  "ignoredRIDs":[
-    "linux-ppc64le",
-    "linux-s390x"
+  "skipWhen": [
+    "runtime=mono" // lldb sos relies on coreclr features
   ]
 }
-

--- a/debugging-via-dotnet-dump/test.json
+++ b/debugging-via-dotnet-dump/test.json
@@ -7,11 +7,8 @@
   "type": "bash",
   "cleanup": true,
   "skipWhen": [
-    "version=8" // see https://github.com/redhat-developer/dotnet-regular-tests/issues/249
-  ],
-  "ignoredRIDs":[
-    "linux-ppc64le",
-    "linux-s390x"
+    "version=8",   // see https://github.com/redhat-developer/dotnet-regular-tests/issues/249
+    "runtime=mono" // dotnet-dump relies on coreclr features
   ]
 }
 


### PR DESCRIPTION
The tests rely on features that are not available with the mono runtime.