### PR TITLE
release-version-sane: skip test on vmr-ci.

### DIFF
--- a/release-version-sane/test.json
+++ b/release-version-sane/test.json
@@ -6,7 +6,7 @@
   "versionSpecific": false,
   "type": "xunit",
   "cleanup": true,
-  "ignoredRIDs":[
-
+  "skipWhen": [
+    "vmr-ci" // see https://github.com/redhat-developer/dotnet-regular-tests/issues/282
   ]
 }


### PR DESCRIPTION
see https://github.com/redhat-developer/dotnet-regular-tests/issues/282