### PR TITLE
Install lttng-ust as dependency explicitly

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,5 +12,5 @@ $ git clone https://github.com/redhat-developer/dotnet-bunny && cd dotnet-bunny 
 
 ### Dependencies
 
-Dependencies(apk): babeltrace bash bash-completion binutils coreutils file findutils g++ jq libstdc++-dev lldb lttng-tools npm postgresql psqlodbc sed strace unixodbc zlib-dev
-Dependencies(dnf): babeltrace bash-completion bc findutils gcc-c++ jq libstdc++-devel lttng-tools npm postgresql-odbc postgresql-server strace unixODBC /usr/bin/file /usr/bin/free /usr/bin/lldb /usr/bin/readelf /usr/bin/su which zlib-devel
+Dependencies(apk): babeltrace bash bash-completion binutils coreutils file findutils g++ jq libstdc++-dev lldb lttng-ust lttng-tools npm postgresql psqlodbc sed strace unixodbc zlib-dev
+Dependencies(dnf): babeltrace bash-completion bc findutils gcc-c++ jq libstdc++-devel lttng-ust lttng-tools npm postgresql-odbc postgresql-server strace unixODBC /usr/bin/file /usr/bin/free /usr/bin/lldb /usr/bin/readelf /usr/bin/su which zlib-devel


### PR DESCRIPTION
It's optional starting with .NET 8 on some environments, so make sure it's correctly installed for the sake of our testing.

Fixes #278