### PR TITLE
adding test coverage for dotnet-trace.

### DIFF
--- a/dotnet-trace/test.json
+++ b/dotnet-trace/test.json
@@ -1,0 +1,9 @@
+{
+	"name": "dotnet-trace",
+	"enabled": true,
+	"requireSdk": true,
+	"version": "6.0",
+	"versionSpecific": false,
+	"type": "bash",
+	"cleanup": false
+}

--- a/dotnet-trace/test.sh
+++ b/dotnet-trace/test.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+set -x
+
+PROJNAME=dotnettrace
+FILENAME=dotnettrace.nettrace
+SPEEDSCOPENAME=dotnettrace.speedscope.json
+REPORTNAME=dotnettrace.nettrace.etlx
+
+dotnet tool update -g dotnet-trace
+export PATH="$HOME/.dotnet/tools:$PATH"
+
+dotnet-trace collect -o $FILENAME -- dotnet new console --output $PROJNAME
+if [ -f $FILENAME ]; then
+   echo "collect - OK"
+else
+   echo "collect - FAIL"
+   rm -r $PROJNAME
+   exit 1
+fi
+
+if dotnet-trace ps; then
+   echo "ps - OK"
+else
+   echo "ps - FAIL"
+   rm -r $PROJNAME
+   rm $FILENAME
+   exit 1
+fi
+
+if dotnet-trace list-profiles; then
+   echo "list-profiles - OK"
+else
+   echo "list-profiles - FAIL"
+   rm -r $PROJNAME
+   rm $FILENAME
+   exit 1
+fi
+
+dotnet-trace convert $FILENAME --format Speedscope
+if [ -f $SPEEDSCOPENAME ]; then
+   echo "convert - OK"
+else
+   echo "convert - FAIL"
+   rm -r $PROJNAME
+   rm $FILENAME
+   exit 1
+fi 
+
+dotnet-trace report $FILENAME topN
+if [ -f $REPORTNAME ]; then
+   echo "report - OK"
+else 
+   echo "report - FAIL"
+   rm -r $PROJNAME
+   rm $FILENAME
+   rm $SPEEDSCOPENAME
+   exit 1
+fi
+
+
+rm -r $PROJNAME
+rm $FILENAME
+rm $SPEEDSCOPENAME
+rm $REPORTNAME


### PR DESCRIPTION
Adding test coverage for the diagnostic tool 'dotnet-trace'. This test covers the basic functions of dotnet-trace to ensure it ran correctly. All of the main commands used in dotnet-trace are covered, the commands being collect, ps, list-profiles, convert and report.

Closes #223