### PR TITLE
follow-up for dotnet-trace

### DIFF
--- a/dotnet-trace/test.json
+++ b/dotnet-trace/test.json
@@ -2,7 +2,7 @@
 	"name": "dotnet-trace",
 	"enabled": true,
 	"requireSdk": true,
-	"version": "6.0",
+	"version": "8.0",
 	"versionSpecific": false,
 	"type": "bash",
 	"cleanup": false,

--- a/dotnet-trace/test.sh
+++ b/dotnet-trace/test.sh
@@ -48,14 +48,22 @@ else
    exit 1
 fi 
 
-dotnet-trace report $FILENAME topN
-if [ -f $REPORTNAME ]; then
-   echo "report - OK"
-else 
+output=$(dotnet-trace report $FILENAME topN)
+if [[ $output == *"Missing Symbol"* ]]; then 
    echo "report - FAIL"
    rm -r $PROJNAME
    rm $FILENAME
    rm $SPEEDSCOPENAME
+   rm $REPORTNAME
+   exit 1
+elif [[ $output == *"Top 5 Functions (Exclusive)"* ]]; then
+   echo "report - OK"
+else
+   echo "report - FAIL"
+   rm -r $PROJNAME
+   rm $FILENAME
+   rm $SPEEDSCOPENAME
+   rm $REPORTNAME
    exit 1
 fi
 


### PR DESCRIPTION
Rewriting a portion of the test for dotnet-trace, specifically dealing with the 'report' command. Instead of verifying that the report log file exists, the test now checks the output of the command to verify that a specific method is on the callstack.