### PR TITLE
Skip dotnet-trace test on s390x

### DIFF
--- a/dotnet-trace/test.json
+++ b/dotnet-trace/test.json
@@ -5,5 +5,8 @@
 	"version": "6.0",
 	"versionSpecific": false,
 	"type": "bash",
-	"cleanup": false
+	"cleanup": false,
+	"skipWhen": [
+		"arch=s390x"  // https://github.com/dotnet/runtime/issues/92891
+	]
 }


### PR DESCRIPTION
It's a known product issue tracked by
https://github.com/dotnet/runtime/issues/92891