### PR TITLE
vmr-ci: enable managed-symbols-available for .NET 8, disable new host-probes-rid-assets-legacy.

### DIFF
--- a/host-probes-rid-assets-legacy/test.json
+++ b/host-probes-rid-assets-legacy/test.json
@@ -6,6 +6,9 @@
   "versionSpecific": false,
   "type": "bash",
   "cleanup": true,
+  "skipWhen": [
+    "vmr-ci" // test fails against stage 1 build (https://github.com/redhat-developer/dotnet-regular-tests/issues/289#issuecomment-1705268294)
+  ],
   "ignoredRIDs":[
   ]
 }

--- a/managed-symbols-available/test.json
+++ b/managed-symbols-available/test.json
@@ -7,7 +7,8 @@
   "type": "bash",
   "cleanup": true,
   "skipWhen": [
-    "vmr-ci" // https://github.com/redhat-developer/dotnet-regular-tests/issues/267
+    "vmr-ci,version=6", // unpacking symbols is a hassle
+    "vmr-ci,version=7",
   ],
   "ignoredRIDs":[
   ]


### PR DESCRIPTION
Fixes https://github.com/redhat-developer/dotnet-regular-tests/issues/267.