### PR TITLE
Use TestTargetFramework to match the framework under test.

### DIFF
--- a/aspnet-same-runtime-version-2x/test.sh
+++ b/aspnet-same-runtime-version-2x/test.sh
@@ -30,7 +30,7 @@ function create_project_for_package()
   cat >$test_folder/testapp.csproj <<EOF
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>netcoreapp${runtime_version_major_minor}</TargetFramework>
+    <TargetFramework>\$(TestTargetFramework)</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="$package" />

--- a/aspnetpatch-21/test.sh
+++ b/aspnetpatch-21/test.sh
@@ -55,7 +55,7 @@ EOF
   cat >$test_folder/testapp.csproj <<EOF
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>\$(TestTargetFramework)</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="$package" />

--- a/assemblies-valid/assemblies-valid.csproj
+++ b/assemblies-valid/assemblies-valid.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>$(TestTargetFramework)</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/cgroup-limit/cgroup-limit.csproj
+++ b/cgroup-limit/cgroup-limit.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>$(TestTargetFramework)</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/equality-and-sort/equality-and-sort.csproj
+++ b/equality-and-sort/equality-and-sort.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>$(TestTargetFramework)</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>

--- a/fdd-no-nuget/fdd-no-nuget.csproj
+++ b/fdd-no-nuget/fdd-no-nuget.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>$(TestTargetFramework)</TargetFramework>
   </PropertyGroup>
 </Project>

--- a/japanese-eras/japanese-eras.csproj
+++ b/japanese-eras/japanese-eras.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>$(TestTargetFramework)</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNetTestSdkVersion)" />

--- a/libuv-kestrel-sample-app-2x/libuv-kestrel-sample-app-2x.csproj
+++ b/libuv-kestrel-sample-app-2x/libuv-kestrel-sample-app-2x.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>$(TestTargetFramework)</TargetFramework>
     <MvcRazorCompileOnPublish>true</MvcRazorCompileOnPublish>
     <UserSecretsId>aspnet-hello_world-DE94012D-DD42-4C41-9932-5D416EA18C14</UserSecretsId>
   </PropertyGroup>

--- a/limits/limits.csproj
+++ b/limits/limits.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>$(TestTargetFramework)</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/linq/linq.csproj
+++ b/linq/linq.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>$(TestTargetFramework)</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/nativeaot/console.csproj
+++ b/nativeaot/console.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>$(TestTargetFramework)</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <AssemblyName>console</AssemblyName>

--- a/nativeaot/test.sh
+++ b/nativeaot/test.sh
@@ -13,14 +13,14 @@ if ! dotnet publish --use-current-runtime /p:PublishAot=true; then
 fi
 
 # Verify the published output contains a single file.
-PUBLISHED_FILE_COUNT=$(ls ./bin/Debug/net*/*/publish | wc -l)
+PUBLISHED_FILE_COUNT=$(ls ./bin/*/net*/*/publish | grep -v console.dbg | wc -l)
 if [ "$PUBLISHED_FILE_COUNT" != "1" ]; then
     echo "FAIL: published NativeAot app contains more than 1 file."
     exit 1
 fi
 
 # Verify the application runs.
-APP_OUTPUT="$(./bin/Debug/net*/*/publish/console 2>&1)"
+APP_OUTPUT="$(./bin/*/net*/*/publish/console 2>&1)"
 if [ "$APP_OUTPUT" != "Hello, World!" ]; then
     echo "FAIL: NativeAot console application did not have expected output."
     exit 1

--- a/pgo-dynamic/pgo-dynamic.csproj
+++ b/pgo-dynamic/pgo-dynamic.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>$(TestTargetFramework)</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <!-- For .NET 8 and later, don't enable it manually and verify that it's enabled by default -->

--- a/release-version-sane/release-version-sane.csproj
+++ b/release-version-sane/release-version-sane.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>$(TestTargetFramework)</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/rest-client/rest-client.csproj
+++ b/rest-client/rest-client.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>$(TestTargetFramework)</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/strerrorr-linkage/strerrorr-linkage.csproj
+++ b/strerrorr-linkage/strerrorr-linkage.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>$(TestTargetFramework)</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>

--- a/system-data-odbc/system-data-odbc.csproj
+++ b/system-data-odbc/system-data-odbc.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>$(TestTargetFramework)</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/use-current-runtime/use-current-runtime.csproj
+++ b/use-current-runtime/use-current-runtime.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>$(TestTargetFramework)</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/version-apis/version-apis.csproj
+++ b/version-apis/version-apis.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>$(TestTargetFramework)</TargetFramework>
     <RootNamespace>DotNetCoreVersionApis</RootNamespace>
 
     <IsPackable>false</IsPackable>

--- a/xunit-smoketest/xunit-smoketest.csproj
+++ b/xunit-smoketest/xunit-smoketest.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>$(TestTargetFramework)</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>


### PR DESCRIPTION
So far the test runner was patching csproj files that were directly below the test directory and named like the test directory.

With the latest test runner release, the target framework is provided as an environment variable. The environment variable makes it possible to use the target framework anywhere in the tests.

It also reduces the noise on 'git diff' as the csproj files will no longer be changed by the test runner.

This change adopts the new environment variable in the existing tests.