### PR TITLE
Extended managed-symbols-available to check ASP.NET Core

### DIFF
--- a/dotnet-directory
+++ b/dotnet-directory
@@ -49,14 +49,15 @@ print_sdk() {
 }
 
 print_framework() {
-    if [[ $# -eq 0 ]]; then
+    if [[ $# -lt 2 ]]; then
         print_err "Missing <version> argument."
         exit 1
     fi
-    local version="$1"
+    local dir_name="$1"
+    local version="$2"
     declare -a versions
     IFS='.-' read -ra versions <<< "${version}"
-    framework_dirs=( "${dotnet_dir}/shared/Microsoft.NETCore.App/${versions[0]}.${versions[1]:-}"* )
+    framework_dirs=( "${dotnet_dir}/shared/$dir_name/${versions[0]}.${versions[1]:-}"* )
     framework_dir="${framework_dirs[0]}"
     if [ ! -d "$framework_dir" ]; then
         print_err "framework directory for $version not found."
@@ -77,8 +78,11 @@ case "$command" in
         print_root "$@"
         ;;
     --framework)
-        print_framework "$@"
+        print_framework "Microsoft.NETCore.App" "$@"
         ;;
+    --aspnet)
+        print_framework "Microsoft.AspNetCore.App" "$@"
+        ;; 
     --sdk)
         print_sdk "$@"
         ;;
@@ -87,3 +91,4 @@ case "$command" in
         print_usage
         exit 1
 esac
+

--- a/managed-symbols-available/test.sh
+++ b/managed-symbols-available/test.sh
@@ -6,6 +6,7 @@ set -euo pipefail
 IFS=$'\n\t'
 
 framework_dir=$(../dotnet-directory --framework "$1")
+aspnet_dir=$(../dotnet-directory --aspnet "$1")
 
 IFS='.-' read -ra VERSION <<< "$1"
 
@@ -20,14 +21,22 @@ if [[ ${VERSION[0]} ==  6 ]] || [[ ${VERSION[0]} == 7 ]]; then
         echo "error: Found some pdb file."
         exit 1
     fi
+
+    find "${aspnet_dir}" -name '*.pdb' || true
+
+    if [[ "$(find "${aspnet_dir}" -name '*.pdb' -printf '.' | wc -c)" -gt 0 ]] ; then
+        echo "error: Found some pdb file."
+        exit 1
+    fi
+
 else
-    echo "We are supposed to be shipping symbol files between .NET Core 2.1 and .NET 5"
+    echo "Checking symbol files..."
 
     ignore_cases=(
         System.Runtime.CompilerServices.Unsafe.dll
     )
-
-    framework_dlls=( $(find "${framework_dir}" -name '*.dll' -type f) )
+    framework_dlls=( $(find "${framework_dir}" -name '*.dll' -type f))
+    framework_dlls+=( $(find "${aspnet_dir}" -name '*.dll' -type f))
     for dll_name in "${framework_dlls[@]}"
     do
         base_dll_name=$(basename "${dll_name}")


### PR DESCRIPTION
Extended the test for managed-symbols-available to ensure that symbols are available for the ASP.NET Core shared framework as well as the .NET Core shared framework.

Closes #308
Signed-off-by: Niall Crowe <nicrowe@redhat.com>