### PR TITLE
Removed blazorwasm-empty template for .NET 8

### DIFF
--- a/template-test/test.sh
+++ b/template-test/test.sh
@@ -14,7 +14,6 @@ dotnet8Templates=(
     apicontroller
     blazor
     blazorwasm
-    blazorwasm-empty
     buildprops
     buildtargets
     classlib


### PR DESCRIPTION
As per PR https://github.com/dotnet/aspnetcore/pull/50554, blazorwasm-empty template is removed for .NET 8 , so removing blazorwasm-empty template from regular test

Fixes #https://github.com/redhat-developer/dotnet-regular-tests/issues/313