### PR TITLE
set tests to run in bash strict mode

### DIFF
--- a/apphost-framework-lookup/test.sh
+++ b/apphost-framework-lookup/test.sh
@@ -8,6 +8,7 @@ fi
 # because that usually contains lots of "errors".
 
 set -euo pipefail
+IFS=$'\n\t'
 set -x
 
 runtime_id="$(../runtime-id --portable)"

--- a/aspnet-same-runtime-version-2x/test.sh
+++ b/aspnet-same-runtime-version-2x/test.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 set -euo pipefail
-
+IFS=$'\n\t'
 set -x
 
 # There's always a version of Microsoft.AspNetCore.App for each

--- a/aspnet-same-runtime-version/test.sh
+++ b/aspnet-same-runtime-version/test.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 set -euo pipefail
+IFS=$'\n\t'
 
 # Check Microsoft.AspNetCore.App's version matches that of Microsoft.NETCore.App
 

--- a/aspnetpatch-21/test.sh
+++ b/aspnetpatch-21/test.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 set -euo pipefail
+IFS=$'\n\t'
 set -x
 
 # Ensure we have an up-to-date value for latest_aspnet_package.

--- a/bash-completion/test.sh
+++ b/bash-completion/test.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 set -euo pipefail
+IFS=$'\n\t'
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 

--- a/bundled-libunwind/test.sh
+++ b/bundled-libunwind/test.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 set -euo pipefail
-
+IFS=$'\n\t'
 set -x
 
 framework_dir=$(../dotnet-directory --framework "$1")

--- a/cgroup-limit/test.sh
+++ b/cgroup-limit/test.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 set -euo pipefail
-
+IFS=$'\n\t'
 set -x
 
 runtime_id="$(../runtime-id)"

--- a/commit-ids-in-binaries/test.sh
+++ b/commit-ids-in-binaries/test.sh
@@ -12,7 +12,6 @@
 
 set -euo pipefail
 IFS=$'\n\t'
-
 set -x
 
 dotnet_home="$(dirname "$(readlink -f "$(command -v dotnet)")")"

--- a/createdump-aspnet/test.sh
+++ b/createdump-aspnet/test.sh
@@ -2,7 +2,7 @@
 
 # Enable "unofficial bash strict mode"
 set -euo pipefail
-
+IFS=$'\n\t'
 set -x
 
 IFS='.-' read -ra VERSION_SPLIT <<< "$1"

--- a/distribution-packages/test.sh
+++ b/distribution-packages/test.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 set -euo pipefail
-
+IFS=$'\n\t'
 set -x
 
 sdk_version="$(dotnet --version)"

--- a/dotnet-info-commit-ids/test.sh
+++ b/dotnet-info-commit-ids/test.sh
@@ -2,7 +2,7 @@
 
 # unofficial bash strict mode
 set -euo pipefail
-
+IFS=$'\n\t'
 set -x
 
 dotnet --info

--- a/dotnet-monitor-works/test.sh
+++ b/dotnet-monitor-works/test.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
 set -euo pipefail
-set -x
 IFS=$'\n\t'
+set -x
 
 IFS='.-' read -ra VERSION_SPLIT <<< "$1" 
 dotnet tool update -g dotnet-monitor --version "${VERSION_SPLIT[0]}.*-*"

--- a/dotnet-trace/test.sh
+++ b/dotnet-trace/test.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 set -euo pipefail
+IFS=$'\n\t'
 set -x
 
 PROJNAME=dotnettrace

--- a/extract-bundle-dir/test.sh
+++ b/extract-bundle-dir/test.sh
@@ -7,6 +7,7 @@ if [ -f /etc/profile ]; then
 fi
 
 set -euo pipefail
+IFS=$'\n\t'
 
 # Verify DOTNET_BUNDLE_EXTRACT_BASE_DIR is set.
 if [[ "${DOTNET_BUNDLE_EXTRACT_BASE_DIR:-}" != "$HOME/.cache/dotnet_bundle_extract" ]]; then

--- a/fdd-no-nuget/test.sh
+++ b/fdd-no-nuget/test.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 
-set +x
+set -euo pipefail
+IFS=$'\n\t'
+set -x
 
 rm -rf ~/.nuget
 

--- a/helloworld/test.sh
+++ b/helloworld/test.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 set -euo pipefail
+IFS=$'\n\t'
 
 PROJNAME=helloworld
 

--- a/host-probes-rid-assets-legacy/test.sh
+++ b/host-probes-rid-assets-legacy/test.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 set -euox pipefail
+IFS=$'\n\t'
 
 # This test is testing the same functionality as host-probes-rid-assets
 # but when opting in to use the legacy graph (by setting System.Runtime.Loader.UseRidGraph=true).

--- a/host-probes-rid-assets/test.sh
+++ b/host-probes-rid-assets/test.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 set -euox pipefail
+IFS=$'\n\t'
 
 # The lib project packages a native library in a rid-specific folder.
 # Only one rid is considered per nuget package.

--- a/liblttng-ust_sys-sdt.h/test.sh
+++ b/liblttng-ust_sys-sdt.h/test.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 set -euo pipefail
+IFS=$'\n\t'
 set -x
 
 RUNTIME_ID=$(../runtime-id)

--- a/libuv-kestrel-sample-app-2x/test.sh
+++ b/libuv-kestrel-sample-app-2x/test.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 set -euo pipefail
-
+IFS=$'\n\t'
 set -x
 
 dotnet restore

--- a/lttng/test.sh
+++ b/lttng/test.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 set -euo pipefail
+IFS=$'\n\t'
 
 SESSION_NAME=my-session
 TEST_FOLDER=/tmp/$SESSION_NAME

--- a/man-pages/test.sh
+++ b/man-pages/test.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 set -euo pipefail
+IFS=$'\n\t'
 
 helpPages=$(dotnet --help | grep -A 999 'SDK commands' | grep -E -B 999 'Common options|Additional commands' | awk 'NR>1 {print $1}' | head -n-2)
 

--- a/nativeaot/test.sh
+++ b/nativeaot/test.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 set -euo pipefail
-
+IFS=$'\n\t'
 set -x
 
 rm -rf bin obj

--- a/omnisharp/test.sh
+++ b/omnisharp/test.sh
@@ -2,7 +2,6 @@
 
 set -euo pipefail
 IFS=$'\n\t'
-
 set -x
 
 rm -rf workdir

--- a/openssl-alpn/test.sh
+++ b/openssl-alpn/test.sh
@@ -3,6 +3,7 @@
 # Make sure .NET Core has linked to SSL_*_alpn_* functions from OpenSSL
 
 set -euo pipefail
+IFS=$'\n\t'
 set -x
 
 dotnet_dir="$(../dotnet-directory)"

--- a/pgo-dynamic/test.sh
+++ b/pgo-dynamic/test.sh
@@ -3,7 +3,7 @@
 # Check if the .NET Runtime can use dynamic PGO at runtime
 
 set -euo pipefail
-
+IFS=$'\n\t'
 set -x
 
 IFS='.-' read -ra VERSION <<< "$1"

--- a/publish-aspnet-selfcontained/test.sh
+++ b/publish-aspnet-selfcontained/test.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 set -euo pipefail
+IFS=$'\n\t'
 set -x
 
 # Clear nuget sources to use the bundled runtime.

--- a/publish-dotnet-selfcontained/test.sh
+++ b/publish-dotnet-selfcontained/test.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 set -euo pipefail
+IFS=$'\n\t'
 set -x
 
 # Clear nuget sources to use the bundled runtime.

--- a/publish-ready-to-run-linux/test.sh
+++ b/publish-ready-to-run-linux/test.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 set -euo pipefail
+IFS=$'\n\t'
 set -x
 
 dotnet new console --no-restore

--- a/publish-ready-to-run/test.sh
+++ b/publish-ready-to-run/test.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 set -euo pipefail
+IFS=$'\n\t'
 set -x
 
 dotnet new console --no-restore

--- a/restore-with-rid/test.sh
+++ b/restore-with-rid/test.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 set -euo pipefail
+IFS=$'\n\t'
 set -x
 
 dotnet new console --no-restore

--- a/system-data-odbc/test.sh
+++ b/system-data-odbc/test.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 set -euo pipefail
-
+IFS=$'\n\t'
 set -x
 
 # This test *must* be run as non-root; postgresql will refuse to start as root.

--- a/system-libunwind/test.sh
+++ b/system-libunwind/test.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 set -euo pipefail
-
+IFS=$'\n\t'
 set -x
 
 framework_dir=$(../dotnet-directory --framework "$1")

--- a/system-openssl/test.sh
+++ b/system-openssl/test.sh
@@ -4,6 +4,7 @@
 # using OpenSSL via dlopen (which is more likely to fail at runtime).
 
 set -euo pipefail
+IFS=$'\n\t'
 set -x
 
 dotnet_dir="$(../dotnet-directory)"

--- a/targeting-packs-bad-files/test.sh
+++ b/targeting-packs-bad-files/test.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 set -euo pipefail
-
+IFS=$'\n\t'
 set -x
 
 dotnet_dir=$(dirname "$(readlink -f "$(command -v dotnet)")")

--- a/telemetry-is-off-by-default/test-telemetry-tcpdump.sh
+++ b/telemetry-is-off-by-default/test-telemetry-tcpdump.sh
@@ -4,6 +4,7 @@
 
 set -euo pipefail
 set -x
+IFS=$'\n\t'
 
 # found via experimentation
 telemetry_host=dc.services.visualstudio.com

--- a/telemetry-is-off-by-default/test.sh
+++ b/telemetry-is-off-by-default/test.sh
@@ -9,6 +9,7 @@
 # access.
 
 set -euo pipefail
+IFS=$'\n\t'
 set -x
 
 no_server=("/nodeReuse:false" "/p:UseSharedCompilation=false" "/p:UseRazorBuildServer=false")

--- a/template-test/test.sh
+++ b/template-test/test.sh
@@ -4,7 +4,8 @@
 # dotnet new <template>
 
 set -euo pipefail
-#set -x
+IFS=$'\n\t'
+set -x
 
 # The list of templates in each version of .NET that we want to test.
 # If additional templates are found via `dotnet new --list`, this test

--- a/tool-dev-certs/test.sh
+++ b/tool-dev-certs/test.sh
@@ -7,6 +7,7 @@ fi
 # Enable "unofficial strict mode" only after loading /etc/profile
 # because that usually contains lots of "errors".
 set -euo pipefail
+IFS=$'\n\t'
 set -x
 
 IFS='.-' read -ra VERSION_SPLIT <<< "$1"

--- a/use-current-runtime/test.sh
+++ b/use-current-runtime/test.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 set -euo pipefail
-
+IFS=$'\n\t'
 set -x
 
 PORTABLE_RID="$(../runtime-id --portable)"

--- a/workload/test.sh
+++ b/workload/test.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 set -euo pipefail
-
+IFS=$'\n\t'
 set -x
 
 # In some environments, such as Github Actions, /tmp/ is strange and

--- a/xunit-smoketest/test.sh
+++ b/xunit-smoketest/test.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 set -euo pipefail
+IFS=$'\n\t'
 
 for TEST_RESULT in pass fail ;
 do


### PR DESCRIPTION
As discussed here: https://github.com/redhat-developer/dotnet-regular-tests/pull/319#discussion_r1397638584 , applicable tests are now being set to run bash strict mode in order to increase maintainability and reliability. More information on bash strict mode can be found here: http://redsymbol.net/articles/unofficial-bash-strict-mode/