### PR TITLE
re-enabling debugging-via-dotnet-dump for .NET 8

### DIFF
--- a/debugging-via-dotnet-dump/test.json
+++ b/debugging-via-dotnet-dump/test.json
@@ -8,7 +8,6 @@
   "cleanup": true,
   "timeoutMultiplier": 2,
   "skipWhen": [
-    "version=8",   // see https://github.com/redhat-developer/dotnet-regular-tests/issues/249
     "runtime=mono" // dotnet-dump relies on coreclr features
   ]
 }


### PR DESCRIPTION
Older issues for dotnet-dump have been resolved and as such the test is expected to pass when run using .NET 8.

Closes #249