### PR TITLE
Refractoring cgroup-limit

### DIFF
--- a/cgroup-limit/test.sh
+++ b/cgroup-limit/test.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 
 set -euo pipefail
-IFS=$'\n\t'
 set -x
 
 runtime_id="$(../runtime-id)"


### PR DESCRIPTION
Removing the line from cgroup-limit that was enabling bash strict mode as it was causing CI failures.