### PR TITLE
Skip dotnet-monitor-works on .NET 6+s390x

### DIFF
--- a/dotnet-monitor-works/test.json
+++ b/dotnet-monitor-works/test.json
@@ -7,5 +7,6 @@
 	"type": "bash",
 	"cleanup": false,
 	"skipWhen": [
+		"version=6,arch=s390x", // https://github.com/redhat-developer/dotnet-regular-tests/issues/325
 	]
 }


### PR DESCRIPTION
We can re-enable it after fixing
https://github.com/redhat-developer/dotnet-regular-tests/issues/325