### PR TITLE
Skip rsa-pkcs-openssl test on RHEL 7

### DIFF
--- a/rsa-pkcs-openssl/test.json
+++ b/rsa-pkcs-openssl/test.json
@@ -8,6 +8,7 @@
   "cleanup": true,
   "skipWhen": [
     "vmr-ci,version=9", // upstream main branch opts out of the OpenSSL change.
+    "os=rhel.7",        // RHEL 7 is not getting OpenSSL changes.
     "os=alpine"         // test validates behavior for Fedora/RHEL.
   ],
   "ignoredRIDs":[


### PR DESCRIPTION
We don't expect OpenSSL on RHEL 7 to receive any fixes.