### PR TITLE
Accept a version string for .NET 9

### DIFF
--- a/version-apis/VersionTest.cs
+++ b/version-apis/VersionTest.cs
@@ -8,7 +8,8 @@ namespace DotNetCoreVersionApis
 {
     public class VersionTest
     {
-        public static readonly int MAX_DOTNET_MAJOR_VERSION = 8;
+        public static readonly int MAX_DOTNET_MAJOR_VERSION = 9;
+
         [Fact]
         public void EnvironmentVersion()
         {


### PR DESCRIPTION
Tthis test fails against the in-development versions of .NET 9 because it only accepts versions up to (and including) 8.