### PR TITLE
Include alpine:edge for .NET 8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,8 +34,6 @@ jobs:
         exclude:
           - container_image: docker.io/library/alpine:latest
             dotnet_version: "8.0"
-          - container_image: docker.io/library/alpine:edge
-            dotnet_version: "8.0"
           - container_image: registry.fedoraproject.org/fedora:rawhide
             dotnet_version: "7.0"
 
@@ -55,7 +53,16 @@ jobs:
           if grep fedora /etc/os-release ; then
             dnf install -y dotnet-sdk-${{ matrix.dotnet_version }}
           elif grep alpine /etc/os-release; then
+            if grep edge /etc/os-release; then
+              echo "https://dl-cdn.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories
+            fi
             apk add dotnet-sdk-${{ matrix.dotnet_version }} dotnet-doc
+            if [[ ! ${{ matrix.dotnet_version }} == *6* ]] && [[ ! ${{ matrix.dotnet_version }} == *7* ]]; then
+              apk add \
+                dotnet-sdk-dbg-${{ matrix.dotnet_version }} \
+                dotnet-runtime-dbg-${{ matrix.dotnet_version }} \
+                aspnetcore-runtime-dbg-${{ matrix.dotnet_version }}
+            fi
           fi
 
       - name: Install Test dependencies
@@ -64,7 +71,7 @@ jobs:
           if grep fedora /etc/os-release ; then
             dnf install -y python3 wget $(grep '^Dependencies(dnf): ' README.md | cut -d: -f2-) --skip-broken
           elif grep alpine /etc/os-release; then
-            apk add python3 wget $(grep '^Dependencies(apk): ' README.md | cut -d: -f2-)
+            apk add python3 wget curl $(grep '^Dependencies(apk): ' README.md | cut -d: -f2-)
             echo -e '[PostgreSQL]\nDescription=PostgreSQL Unicode\nDriver=/usr/lib/psqlodbcw.so\nUsageCount=1' > /etc/odbcinst.ini
           fi
 

--- a/host-probes-rid-assets-legacy/test.json
+++ b/host-probes-rid-assets-legacy/test.json
@@ -7,6 +7,7 @@
   "type": "bash",
   "cleanup": true,
   "skipWhen": [
+    "os=alpine", // see https://github.com/redhat-developer/dotnet-regular-tests/issues/330#issuecomment-1911461723
     "vmr-ci" // test fails against stage 1 build (https://github.com/redhat-developer/dotnet-regular-tests/issues/289#issuecomment-1705268294)
   ],
   "ignoredRIDs":[

--- a/limits/LimitsTest.cs
+++ b/limits/LimitsTest.cs
@@ -9,8 +9,8 @@ public class LimitsTest
     [Fact]
     public void FileDescriptorLimitIsAtMax()
     {
-        int softLimit = int.Parse(RunAndGetProcessOutput("ulimit", new List<string> { "-Sn" }), CultureInfo.InvariantCulture);
-        int hardLimit = int.Parse(RunAndGetProcessOutput("ulimit", new List<string> { "-Hn" }), CultureInfo.InvariantCulture);
+        int softLimit = int.Parse(RunAndGetProcessOutput("../../../ulimit-wrapper.sh", new List<string> { "-Sn" }), CultureInfo.InvariantCulture);
+        int hardLimit = int.Parse(RunAndGetProcessOutput("../../../ulimit-wrapper.sh", new List<string> { "-Hn" }), CultureInfo.InvariantCulture);
 
         Assert.True(hardLimit == softLimit, $"File descriptor soft limit ({softLimit}) should be the same as the hard limit ({hardLimit}).");
     }

--- a/limits/ulimit-wrapper.sh
+++ b/limits/ulimit-wrapper.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+builtin ulimit "$@"


### PR DESCRIPTION
.NET 8 was merged yesterday, and thus now available on edge. It'll be available on latest in May once Alpine 3.20 comes out.