### PR TITLE
Disable tests that fail on armv7

### DIFF
--- a/debugging-sos-lldb-via-core/test.json
+++ b/debugging-sos-lldb-via-core/test.json
@@ -6,6 +6,9 @@
   "versionSpecific": false,
   "type": "bash",
   "cleanup": true,
+  "ignoredRIDs": [
+     "linux-arm" // lldb sos relies on features not implemented on arm
+  ],
   "skipWhen": [
     "runtime=mono" // lldb sos relies on coreclr features
   ]

--- a/debugging-via-dotnet-dump/test.json
+++ b/debugging-via-dotnet-dump/test.json
@@ -7,6 +7,9 @@
   "type": "bash",
   "cleanup": true,
   "timeoutMultiplier": 2,
+  "ignoredRIDs": [
+     "linux-arm" // dotnet-dump relies on features not implemented on arm
+  ],
   "skipWhen": [
     "runtime=mono" // dotnet-dump relies on coreclr features
   ]

--- a/nativeaot/test.json
+++ b/nativeaot/test.json
@@ -9,5 +9,8 @@
   "skipWhen": [
     "runtime=mono", // nativeaot is not available with mono
     "vmr-ci"        // nativeaot packages not published
+  ],
+  "ignoredRIDs": [
+    "linux-arm" // nativeaot not supported on arm
   ]
 }

--- a/pgo-dynamic/test.json
+++ b/pgo-dynamic/test.json
@@ -6,6 +6,9 @@
   "versionSpecific": false,
   "type": "bash",
   "cleanup": true,
+  "ignoredRIDs": [
+    "linux-arm" // pgo optimization not supported on arm
+  ],
   "skipWhen": [
     "runtime=mono"
   ]

--- a/template-test/test.sh
+++ b/template-test/test.sh
@@ -312,9 +312,9 @@ function testTemplate {
 
     echo "### Testing: ${templateName}"
 
-    if [[ ( $(uname -m) == "s390x" ||  $(uname -m) == "ppc64le" ) && ( "${templateName}" == "webapiaot" ) ]]; then
-        # webapiaot implies AOT which will not even restore on mono (ppc64le/s390x), skip it
-        echo "SKIP skipping webapiaot on ppc64/s390x"
+	if [[ ( $(uname -m) == "s390x" ||  $(uname -m) == "ppc64le" || $(uname -m) == "armv7" ) && ( "${templateName}" == "webapiaot" ) ]]; then
+        # webapiaot implies AOT which will not even restore on mono (ppc64le/s390x) and armv7, skip it
+        echo "SKIP skipping webapiaot on ppc64/s390x/armv7"
         return
     fi
 


### PR DESCRIPTION
A few test units fail on on armv7, which I suppose has to do with certain features not implemented on coreclr-arm:
* nativeaot: AOT not implemented on arm
* pgo-dynamic: pgo-dynamic not inplemented on arm

These I'm not sure if they are implemented on armv7:
* debugging-via-dotnet-dump
* debugging-sos-lldb-via-dump