### PR TITLE
tools-in-path should use framework version, not sdk version.

### DIFF
--- a/tools-in-path/test.sh
+++ b/tools-in-path/test.sh
@@ -19,7 +19,7 @@ else
     exit 1
 fi
 
-IFS='.-' read -ra VERSION_SPLIT <<< "$1" 
-dotnet tool update -g dotnet-ef --version "${VERSION_SPLIT[0]}.*-*"
+framework_dir=$(../dotnet-directory --framework "$1")
+dotnet tool update -g dotnet-ef --version "${framework_dir#*App/}.*-*"
 
 dotnet ef --version


### PR DESCRIPTION
tools-in-path is failing on dotnet 8.0.0 as in that version of dotnet the sdk version is written as "8.0.1" whereas the framework is 8.0.0. This causes an issue when installing dotnet-ef as it will go by the sdk version and there is a newer version of dotnet-ef for dotnet 8.0.101, causing a compatibly issue when used with dotnet 8.0.0 as it will automatically download the newest version of dotnet-ef for 8.0.1 . Due to this it would be better to download the version of dotnet-ef that matches the framework version of dotnet, rather than the sdk.