### PR TITLE
shorter socket path for system-data-odbc

### DIFF
--- a/system-data-odbc/test.sh
+++ b/system-data-odbc/test.sh
@@ -29,7 +29,7 @@ export PGDATA
 export PGHOST=localhost
 export PGPORT=$((1024 + $RANDOM ))
 
-PGSOCKET="$(pwd)/socket"
+PGSOCKET="$(mktemp -d)/socket"
 
 rm -rf "$PGDATA" "$PGSOCKET"
 mkdir -p "$PGDATA" "$PGSOCKET"


### PR DESCRIPTION
system-data-odbc now creates a temporary directory to use for the socket path in order to stay below the 108 bytes socket path limit.

Closes #336