### PR TITLE
Fix CI errors - skip the test on nonrpm validation

### DIFF
--- a/distribution-packages/test.json
+++ b/distribution-packages/test.json
@@ -6,7 +6,8 @@
   "type": "bash",
   "cleanup": true,
   "skipWhen": [
-    "vmr-ci" // not packaged (tar.gz build)
+    "vmr-ci", // not packaged (tar.gz build)
+    "non-rpm"
   ],
   "ignoredRIDs":[
     "rhel7",

--- a/distribution-packages/test.json
+++ b/distribution-packages/test.json
@@ -7,7 +7,7 @@
   "cleanup": true,
   "skipWhen": [
     "vmr-ci", // not packaged (tar.gz build)
-    "non-rpm"
+    "non-packaged",
   ],
   "ignoredRIDs":[
     "rhel7",

--- a/managed-symbols-available/test.json
+++ b/managed-symbols-available/test.json
@@ -9,7 +9,7 @@
   "skipWhen": [
     "vmr-ci,version=6", // unpacking symbols is a hassle
     "vmr-ci,version=7",
-    "non-rpm"
+    "non-packaged",
   ],
   "ignoredRIDs":[
   ]

--- a/managed-symbols-available/test.json
+++ b/managed-symbols-available/test.json
@@ -9,6 +9,7 @@
   "skipWhen": [
     "vmr-ci,version=6", // unpacking symbols is a hassle
     "vmr-ci,version=7",
+    "non-rpm"
   ],
   "ignoredRIDs":[
   ]


### PR DESCRIPTION
Fix the CI errors by skipping the dotnet regular tests since the "distribution-packages" and "managed-symbols-available" tests should only run while validating the RPMs. They need not run which we validate the tarball or cross build SDKs.