### PR TITLE
CentOS Stream 8 is EOL

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,6 @@ jobs:
         container_image:
           - docker.io/library/alpine:latest
           - docker.io/library/alpine:edge
-          - quay.io/centos/centos:stream8
           - quay.io/centos/centos:stream9
           - registry.fedoraproject.org/fedora:39
           - registry.fedoraproject.org/fedora:40
@@ -30,9 +29,6 @@ jobs:
         dotnet_version:
           - "6.0"
           - "8.0"
-        exclude:
-          - container_image: docker.io/library/alpine:latest
-            dotnet_version: "8.0"
 
     container:
       image: ${{ matrix.container_image }}


### PR DESCRIPTION
Remove it from CI matrix

.NET 8 is also avaialble in alpine:latest now.