### PR TITLE
skip tests run as "non-packaged" (non-rpm) validation

### DIFF
--- a/bash-completion/test.json
+++ b/bash-completion/test.json
@@ -7,7 +7,8 @@
   "type": "bash",
   "cleanup": true,
   "skipWhen": [
-    "vmr-ci" // bash completion script not installed
+    "vmr-ci", // bash completion script not installed
+    "non-packaged",
   ],
   "ignoredRIDs":[
   ]

--- a/file-permissions/test.json
+++ b/file-permissions/test.json
@@ -7,7 +7,8 @@
   "type": "bash",
   "cleanup": true,
   "skipWhen": [
-    "vmr-ci" // not packaged (tar.gz build)
+    "vmr-ci", // not packaged (tar.gz build)
+    "non-packaged",
   ],
   "ignoredRIDs":[
 

--- a/man-pages/test.json
+++ b/man-pages/test.json
@@ -7,7 +7,8 @@
   "type": "bash",
   "cleanup": true,
   "skipWhen": [
-    "vmr-ci" // man page not installed
+    "vmr-ci", // man page not installed
+    "non-packaged",
   ],
   "ignoredRIDs":[
   ]

--- a/openssl-alpn/test.json
+++ b/openssl-alpn/test.json
@@ -6,6 +6,9 @@
   "versionSpecific": false,
   "type": "bash",
   "cleanup": true,
+  "skipWhen": [
+    "non-packaged",
+  ],
   "ignoredRIDs":[
   ]
 }

--- a/publish-aspnet-selfcontained/test.json
+++ b/publish-aspnet-selfcontained/test.json
@@ -5,6 +5,9 @@
   "version": "8.0",
   "versionSpecific": false,
   "type": "bash",
-  "cleanup": true
+  "cleanup": true,
+  "skipWhen": [
+    "non-packaged",
+  ],
 }
 

--- a/publish-dotnet-selfcontained/test.json
+++ b/publish-dotnet-selfcontained/test.json
@@ -5,6 +5,9 @@
   "version": "8.0",
   "versionSpecific": false,
   "type": "bash",
-  "cleanup": true
+  "cleanup": true,
+  "skipWhen": [
+    "non-packaged",
+  ],
 }
 

--- a/restore-with-rid/test.json
+++ b/restore-with-rid/test.json
@@ -8,6 +8,7 @@
   "cleanup": true,
   "skipWhen":[
     "version=6,arch=s390x", // no runtime pack available
+    "non-packaged",
   ],
   "ignoredRIDs":[
   ]

--- a/rsa-pkcs-openssl/test.json
+++ b/rsa-pkcs-openssl/test.json
@@ -9,7 +9,8 @@
   "skipWhen": [
     "vmr-ci",           // upstream opts out of the OpenSSL change.
     "os=rhel.7",        // RHEL 7 is not getting OpenSSL changes.
-    "os=alpine"         // test validates behavior for Fedora/RHEL.
+    "os=alpine",         // test validates behavior for Fedora/RHEL.
+    "non-packaged",
   ],
   "ignoredRIDs":[
   ]

--- a/sha1-validation/test.json
+++ b/sha1-validation/test.json
@@ -7,6 +7,7 @@
     "type": "bash",
     "cleanup": true,
     "skipWhen": [
+      "non-packaged",
     ],
     "ignoredRIDs":[
     ]

--- a/system-openssl/test.json
+++ b/system-openssl/test.json
@@ -6,6 +6,9 @@
   "versionSpecific": false,
   "type": "bash",
   "cleanup": true,
+  "skipWhen": [
+    "non-packaged",
+  ],
   "ignoredRIDs":[
   ]
 }

--- a/tools-in-path/test.json
+++ b/tools-in-path/test.json
@@ -6,7 +6,8 @@
   "type": "bash",
   "cleanup": true,
   "skipWhen": [
-    "vmr-ci" // tools PATH not configured (tar.gz build)
+    "vmr-ci", // tools PATH not configured (tar.gz build)
+    "non-packaged",
   ],
   "ignoredRIDs": [
   ]


### PR DESCRIPTION
Added changes to skip the dotnet regular tests which are not required to run during cross build SDK validation.