### PR TITLE
Update package dependencies to latest stable versions.

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,9 +4,9 @@
          You can change it locally when running without the test runner to match with the .NET SDK under test. -->
     <TestTargetFramework Condition="'$(TestTargetFramework)' == ''">net6.0</TestTargetFramework>
 
-    <SystemDataOdbcVersion>6.0.0</SystemDataOdbcVersion>
-    <MicrosoftNetTestSdkVersion>17.4.0</MicrosoftNetTestSdkVersion>
-    <XunitVersion>2.4.1</XunitVersion>
-    <XunitRunnerVisualStudioVersion>2.4.3</XunitRunnerVisualStudioVersion>
+    <SystemDataOdbcVersion>8.0.0</SystemDataOdbcVersion>
+    <MicrosoftNetTestSdkVersion>17.10.0</MicrosoftNetTestSdkVersion>
+    <XunitVersion>2.8.1</XunitVersion>
+    <XunitRunnerVisualStudioVersion>2.8.1</XunitRunnerVisualStudioVersion>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
The current version we have for the test framework references vulnerable versions for System.Net.Http and System.Text.RegularExpressions which causes the test projects to fail to build with the latest .NET 9 SDK.

This updates all dependencies to their latest stable versions.

cc @nicrowe00 @omajid 