### PR TITLE
Add .NET 9 to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,9 @@ jobs:
         dotnet_version:
           - "6.0"
           - "8.0"
+        include:
+          - container_image: registry.fedoraproject.org/fedora:40
+            dotnet_version: "9.0"
 
     container:
       image: ${{ matrix.container_image }}
@@ -44,6 +47,10 @@ jobs:
           set -euo pipefail
           cat /etc/os-release
           if grep fedora /etc/os-release ; then
+            if [[ ${{ matrix.dotnet_version }} == 9.* ]]; then
+              dnf install 'dnf-command(copr)' -y
+              dnf copr enable @dotnet-sig/dotnet-preview -y
+            fi
             dnf install -y dotnet-sdk-${{ matrix.dotnet_version }}
             if [[ ! ${{ matrix.dotnet_version }} == *6* ]]; then
               dnf install -y \

--- a/distribution-packages/test.sh
+++ b/distribution-packages/test.sh
@@ -6,12 +6,14 @@ set -x
 
 sdk_version="$(dotnet --version)"
 runtime_version="$(dotnet --list-runtimes | grep Microsoft.NETCore.App | awk '{ print $2 }')"
+aspnetcore_runtime_version="$(dotnet --list-runtimes | grep Microsoft.AspNetCore.App | awk '{ print $2 }')"
 runtime_id=$(../runtime-id)
 # This might be the final/only netstandard version from now on
 netstandard_version=2.1
 
 ./test-standard-packages \
     "${runtime_id}" \
-    "${runtime_version}" "${runtime_version}" \
+    "${runtime_version}" \
+    "${aspnetcore_runtime_version}" \
     "${sdk_version}" \
     "${netstandard_version}"

--- a/tools-in-path/test.sh
+++ b/tools-in-path/test.sh
@@ -20,6 +20,12 @@ else
 fi
 
 framework_dir=$(../dotnet-directory --framework "$1")
-dotnet tool update -g dotnet-ef --version "${framework_dir#*App/}.*"
+runtime_version=${framework_dir#*App/}
+if [[ $runtime_version = *preview* ]] || [[ $runtime_version = *rc* ]]; then
+    # delete the last digit (which is the build version)
+    runtime_version=$(echo $runtime_version | sed -E 's|.[[:digit:]]+$||')
+fi
+tool_version="$runtime_version.*"
+dotnet tool update -g dotnet-ef --version "$tool_version"
 
 dotnet ef --version


### PR DESCRIPTION
Test the in-development .NET 9 RPM as a way to find out how well dotnet-regular-tests are working against .NET 9.