### PR TITLE
Update CI config: .NET 6.0 is not part of Rawhide

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,9 @@ jobs:
         dotnet_version:
           - "6.0"
           - "8.0"
+        exclude:
+          - container_image: registry.fedoraproject.org/fedora:rawhide
+            dotnet_version: "6.0"
         include:
           - container_image: registry.fedoraproject.org/fedora:40
             dotnet_version: "9.0"


### PR DESCRIPTION
It was removed from there and we shouldn't try testing it: https://lists.fedoraproject.org/archives/list/dotnet-sig@lists.fedoraproject.org/thread/WRSA4NT74RUI3UZJENHJMH5S7WCZW6DP/