### PR TITLE
Add a test for non-portable SDK RID

### DIFF
--- a/distribution-packages/test.sh
+++ b/distribution-packages/test.sh
@@ -7,7 +7,7 @@ set -x
 sdk_version="$(dotnet --version)"
 runtime_version="$(dotnet --list-runtimes | grep Microsoft.NETCore.App | awk '{ print $2 }')"
 aspnetcore_runtime_version="$(dotnet --list-runtimes | grep Microsoft.AspNetCore.App | awk '{ print $2 }')"
-runtime_id=$(../runtime-id)
+runtime_id=$(../runtime-id --sdk)
 # This might be the final/only netstandard version from now on
 netstandard_version=2.1
 

--- a/non-portable-rid/test.json
+++ b/non-portable-rid/test.json
@@ -1,0 +1,12 @@
+{
+  "name": "non-portable-rid",
+  "enabled": true,
+  "requiresSdk": true,
+  "version": "6.0",
+  "versionSpecific": false,
+  "type": "bash",
+  "cleanup": true,
+  "skipWhen":[
+    "portable", // this test only tests non-portable SDKs
+  ]
+}

--- a/non-portable-rid/test.sh
+++ b/non-portable-rid/test.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+IFS=$'\n\t'
+set -x
+
+sdk_rid="$(../runtime-id --sdk)"
+os_rid="$(../runtime-id)"
+
+if [[ $sdk_rid != $os_rid ]]; then
+    echo "SDK RID ($sdk_rid) did not match expected RID ($os_rid)"
+    exit 1
+fi

--- a/publish-ready-to-run/test.sh
+++ b/publish-ready-to-run/test.sh
@@ -5,4 +5,4 @@ IFS=$'\n\t'
 set -x
 
 dotnet new console --no-restore
-dotnet publish -r "$(../runtime-id)" /p:PublishReadyToRun=true
+dotnet publish -r "$(../runtime-id --sdk)" /p:PublishReadyToRun=true


### PR DESCRIPTION
We have recently updated a number of tests to use the SDK's RID (instead of the expected OS non-portable RID). We should have a test that explicitly tests that the SDK's RID matches the expected OS-specific non-portable RID. This is that test.