### PR TITLE
Fix hardened-binaries test for .NET 9

### DIFF
--- a/hardened-binaries/test.sh
+++ b/hardened-binaries/test.sh
@@ -3,12 +3,15 @@
 set -euo pipefail
 IFS=$'\n\t'
 
+set -x
+
 root=$(dirname "$(readlink -f "$(command -v dotnet)")")
 echo ".NET Core base directory: $root"
 
-# TODO handle more architectures can just x86-64
-
-file_list=$(find "$root/" -type f -exec file {} \; | grep -E 'ELF [[:digit:]][[:digit:]]-bit [LM]SB' | cut -d: -f 1 | sort -u)
+file_list=$(find "$root/" -type f -not -iname '*.o' -exec file {} \; \
+            | grep -E 'ELF [[:digit:]][[:digit:]]-bit [LM]SB' \
+            | cut -d: -f 1 \
+            | sort -u)
 mapfile -t binaries <<< "$file_list"
 for binary in "${binaries[@]}"; do
     echo "$binary"


### PR DESCRIPTION
With .NET 9, the NativeAOT feature results in the inclusion of a few .o (object) files in the SDK. The `file` reports those as:

    /usr/lib64/dotnet/.../libbootstrapper.o: ELF 64-bit LSB...

Which means the test then tries to check if it was linked with BIND_NOW and GNU_RELRO. That doesn't make any sense, because this isn't a shared library or an executable that the linker has run over.

Fix that by skipping testing any `.o` files.