### PR TITLE
Update ci matrix and .NET installation instructions.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,73 +21,56 @@ jobs:
           - docker.io/library/alpine:latest
           - docker.io/library/alpine:edge
           - quay.io/centos/centos:stream9
-          - quay.io/centos/centos:stream10-development
-          - registry.fedoraproject.org/fedora:39
+          - quay.io/centos/centos:stream10
           - registry.fedoraproject.org/fedora:40
+          - registry.fedoraproject.org/fedora:41
           - registry.fedoraproject.org/fedora:rawhide
           - registry.access.redhat.com/ubi8
           - registry.access.redhat.com/ubi9
         dotnet_version:
-          - "6.0"
           - "8.0"
+          - "9.0"
         exclude:
-          - container_image: registry.fedoraproject.org/fedora:rawhide
-            dotnet_version: "6.0"
-          - container_image: quay.io/centos/centos:stream10-development
-            dotnet_version: "6.0"
-        include:
-          - container_image: registry.fedoraproject.org/fedora:40
+          - container_image: docker.io/library/alpine:latest
             dotnet_version: "9.0"
-          - container_image: registry.fedoraproject.org/fedora:rawhide
-            dotnet_version: "9.0"
-          - container_image: quay.io/centos/centos:stream10-development
+          - container_image: docker.io/library/alpine:edge
             dotnet_version: "9.0"
 
     container:
       image: ${{ matrix.container_image }}
       options: --security-opt seccomp=unconfined
 
-
     steps:
       - uses: actions/checkout@v4
 
       - name: Install .NET ${{ matrix.dotnet_version }}
-        # .NET 9 is a preview and requires 'copr' for installation.
         # .NET 9 introduced the 'dotnet-sdk-aot' package
         # .NET 8 introduced the 'dbg' packages
         # '/etc/os-release' will also match the grep fedora for Fedora derived systems, such as CentOS.
         timeout-minutes: 10
         run: |
-
           set -euo pipefail
           cat /etc/os-release
-          if [[ ${{ matrix.dotnet_version }} == 9.* ]]; then
-            dnf install 'dnf-command(copr)' -y
-            if grep centos /etc/os-release; then
-              dnf copr enable @dotnet-sig/dotnet-preview centos-stream-10-x86_64 -y
-            else
-              dnf copr enable @dotnet-sig/dotnet-preview -y
-            fi
-            dnf install -y dotnet-sdk-aot-${{ matrix.dotnet_version }}
-          fi
           if grep fedora /etc/os-release; then
             dnf install -y dotnet-sdk-${{ matrix.dotnet_version }}
-              if [[ ! ${{ matrix.dotnet_version }} == *6* ]]; then
-                dnf install -y \
-                  dotnet-sdk-dbg-${{ matrix.dotnet_version }} \
-                  dotnet-runtime-dbg-${{ matrix.dotnet_version }} \
-                  aspnetcore-runtime-dbg-${{ matrix.dotnet_version }}
-              fi
+            dnf install -y \
+              dotnet-sdk-dbg-${{ matrix.dotnet_version }} \
+              dotnet-runtime-dbg-${{ matrix.dotnet_version }} \
+              aspnetcore-runtime-dbg-${{ matrix.dotnet_version }}
+            if [[ ${{ matrix.dotnet_version }} == 9.* ]]; then
+              dnf install -y dotnet-sdk-aot-${{ matrix.dotnet_version }}
+            fi
           elif grep alpine /etc/os-release; then
             if grep edge /etc/os-release; then
               echo "https://dl-cdn.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories
             fi
             apk add dotnet-sdk-${{ matrix.dotnet_version }} dotnet-doc
-            if [[ ! ${{ matrix.dotnet_version }} == *6* ]]; then
-              apk add \
-                dotnet-sdk-dbg-${{ matrix.dotnet_version }} \
-                dotnet-runtime-dbg-${{ matrix.dotnet_version }} \
-                aspnetcore-runtime-dbg-${{ matrix.dotnet_version }}
+            apk add \
+              dotnet-sdk-dbg-${{ matrix.dotnet_version }} \
+              dotnet-runtime-dbg-${{ matrix.dotnet_version }} \
+              aspnetcore-runtime-dbg-${{ matrix.dotnet_version }}
+            if [[ ${{ matrix.dotnet_version }} == 9.* ]]; then
+              apk add dotnet-sdk-aot-${{ matrix.dotnet_version }}
             fi
           fi
 


### PR DESCRIPTION
Adding Fedora41 to the CI matrix while also removing Fedora39. .NET 6 has also been removed.
The installation steps for .NET 9 have been updated now that it has been publically released.