### PR TITLE
Eliminate dependency on .NET 10's non source-buildable Microsoft.AspNetCore.App.Internal.Assets package.

### DIFF
--- a/cgroup-limit/cgroup-limit.csproj
+++ b/cgroup-limit/cgroup-limit.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <OutputType>Exe</OutputType>
     <TargetFramework>$(TestTargetFramework)</TargetFramework>
   </PropertyGroup>
 

--- a/cgroup-limit/cgroup-limit.csproj
+++ b/cgroup-limit/cgroup-limit.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>$(TestTargetFramework)</TargetFramework>

--- a/createdump-aspnet/test.sh
+++ b/createdump-aspnet/test.sh
@@ -9,12 +9,12 @@ IFS='.-' read -ra VERSION_SPLIT <<< "$1"
 
 version=${VERSION_SPLIT[0]}.${VERSION_SPLIT[1]}
 
-dotnet new web --force
+dotnet new web --no-restore --force
 
 sed -i -e 's|.UseStartup|.UseUrls("http://localhost:5000").UseStartup|' Program.cs
 
 # Do not kick off compiler servers that hang around after a build
-dotnet build -p:UseRazorBuildServer=false -p:UseSharedCompilation=false /m:1
+dotnet build -p:UseRazorBuildServer=false -p:UseSharedCompilation=false /p:UsingMicrosoftNETSdkRazor=false /p:ScopedCssEnabled=false /m:1
 
 dotnet run --no-build --no-restore &
 sleep 5

--- a/debugging-sos-lldb-via-core/test.sh
+++ b/debugging-sos-lldb-via-core/test.sh
@@ -58,9 +58,9 @@ rm -rf TestDir
 mkdir TestDir
 cd TestDir
 
-dotnet new web
+dotnet new web --no-restore
 sed -i -e 's|.UseStartup|.UseUrls("http://localhost:5000").UseStartup|' Program.cs
-dotnet build "${no_server[@]}"
+dotnet build "${no_server[@]}" /p:UsingMicrosoftNETSdkRazor=false /p:ScopedCssEnabled=false
 
 dotnet bin/Debug/net*/TestDir.dll &
 run_pid=$!

--- a/debugging-via-dotnet-dump/test.sh
+++ b/debugging-via-dotnet-dump/test.sh
@@ -94,7 +94,7 @@ dotnet tool install -g dotnet-dump
 framework_dir=$(../dotnet-directory --framework "${sdk_version}")
 test -f "${framework_dir}/createdump"
 
-no_server=("/nodeReuse:false" "/p:UseSharedCompilation=false" "/p:UseRazorBuildServer=false")
+no_server=("/nodeReuse:false" "/p:UseSharedCompilation=false" "/p:UseRazorBuildServer=false" "/p:UsingMicrosoftNETSdkRazor=false" "/p:ScopedCssEnabled=false")
 
 heading "Running test application"
 
@@ -102,7 +102,7 @@ rm -rf TestDir
 mkdir TestDir
 cd TestDir
 
-dotnet new web
+dotnet new web --no-restore
 sed -i -e 's|.UseStartup|.UseUrls("http://localhost:5000").UseStartup|' Program.cs
 dotnet build "${no_server[@]}"
 

--- a/publish-aspnet-selfcontained/test.sh
+++ b/publish-aspnet-selfcontained/test.sh
@@ -21,8 +21,8 @@ url="http://localhost:5000"
 dir=web
 output_dir=output
 rm -rf "$dir" "$output_dir"
-dotnet new web -o "$dir"
-dotnet publish --sc -r "$runtime_id" -o "$output_dir" "$dir" 
+dotnet new web --no-restore -o "$dir"
+dotnet publish --sc -r "$runtime_id" -o "$output_dir" /p:UsingMicrosoftNETSdkRazor=false /p:ScopedCssEnabled=false "$dir"
 
 ASPNETCORE_URLS="$url" "./$output_dir/web" &
 run_pid=$!

--- a/telemetry-is-off-by-default/test-telemetry-tcpdump.sh
+++ b/telemetry-is-off-by-default/test-telemetry-tcpdump.sh
@@ -16,8 +16,8 @@ sleep 2
 rm -rf WebTest
 mkdir -p WebTest
 pushd WebTest
-dotnet new web >/dev/null 2>&1 || true
-dotnet publish
+dotnet new web --no-restore >/dev/null 2>&1 || true
+dotnet publish /p:UsingMicrosoftNETSdkRazor=false /p:ScopedCssEnabled=false
 popd
 sleep 2
 sudo --non-interactive pkill tcpdump

--- a/telemetry-is-off-by-default/test.sh
+++ b/telemetry-is-off-by-default/test.sh
@@ -12,7 +12,7 @@ set -euo pipefail
 IFS=$'\n\t'
 set -x
 
-no_server=("/nodeReuse:false" "/p:UseSharedCompilation=false" "/p:UseRazorBuildServer=false")
+no_server=("/nodeReuse:false" "/p:UseSharedCompilation=false" "/p:UseRazorBuildServer=false" "/p:UsingMicrosoftNETSdkRazor=false" "/p:ScopedCssEnabled=false")
 
 IFS='.-' read -ra VERSION_SPLIT <<< "$1"
 DOTNET_MAJOR="${VERSION_SPLIT[0]}"


### PR DESCRIPTION
This enables running tests against .NET 10 build which are currently failing due to https://github.com/redhat-developer/dotnet-regular-tests/issues/368/. Once the upstream issue is fixed, these changes can be reverted.