### PR TITLE
Use ITestOutputHelper instead of Console.WriteLine

### DIFF
--- a/assemblies-valid/AssembliesValid.cs
+++ b/assemblies-valid/AssembliesValid.cs
@@ -11,6 +11,7 @@ using System.Runtime.InteropServices;
 using System.Text;
 using System.Text.RegularExpressions;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace AssembliesValid
 {
@@ -40,6 +41,13 @@ namespace AssembliesValid
             new Regex("/packs/"),
         };
 
+        private readonly ITestOutputHelper _output;
+
+        public AssembliesValid(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
         [Fact]
         public void ValidateAssemblies()
         {
@@ -47,15 +55,15 @@ namespace AssembliesValid
             int exitCode = RunProcessAndGetOutput(new string[] { "bash", "-c", "command -v dotnet" }, out dotnetPath);
             if (exitCode != 0)
             {
-                Console.Error.WriteLine("'dotnet' command not found");
-                Console.Error.WriteLine("PATH: " + Environment.GetEnvironmentVariable("PATH"));
+                _output.WriteLine("'dotnet' command not found");
+                _output.WriteLine("PATH: " + Environment.GetEnvironmentVariable("PATH"));
                 Assert.True(false);
             }
             dotnetPath = dotnetPath.Trim();
             exitCode = RunProcessAndGetOutput(new string[] { "readlink", "-f", dotnetPath }, out dotnetPath);
             if (exitCode != 0)
             {
-                Console.Error.WriteLine($"Unable to run readlink -f {dotnetPath}");
+                _output.WriteLine($"Unable to run readlink -f {dotnetPath}");
                 Assert.True(false);
             }
             dotnetPath = dotnetPath.Trim();
@@ -63,7 +71,7 @@ namespace AssembliesValid
             string searchRoot = new FileInfo(dotnetPath).DirectoryName;
             var searchRootDirectory = new System.IO.DirectoryInfo(searchRoot);
 
-            Console.WriteLine($"Searching for dotnet binaries in {searchRoot}");
+            _output.WriteLine($"Searching for dotnet binaries in {searchRoot}");
 
             var architecture = RuntimeInformation.OSArchitecture;
             var machine = GetCurrentMachine(architecture);
@@ -106,11 +114,11 @@ namespace AssembliesValid
 
                         if (valid)
                         {
-                            Console.WriteLine($"{assembly}: OK");
+                            _output.WriteLine($"{assembly}: OK");
                         }
                         else
                         {
-                            Console.WriteLine($"error: {assembly} hasMethods: {hasMethods}, hasAot: {hasAot}, inReleaseMode: {inReleaseMode}");
+                            _output.WriteLine($"error: {assembly} hasMethods: {hasMethods}, hasAot: {hasAot}, inReleaseMode: {inReleaseMode}");
                             allOkay = false;
                         }
                     }

--- a/version-apis/VersionTest.cs
+++ b/version-apis/VersionTest.cs
@@ -3,6 +3,7 @@ using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace DotNetCoreVersionApis
 {
@@ -10,11 +11,18 @@ namespace DotNetCoreVersionApis
     {
         public static readonly int MAX_DOTNET_MAJOR_VERSION = 10;
 
+        private readonly ITestOutputHelper _output;
+
+        public VersionTest(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
         [Fact]
         public void EnvironmentVersion()
         {
             var version = Environment.Version;
-            Console.WriteLine($"Environment.Version: {version}");
+            _output.WriteLine($"Environment.Version: {version}");
             Assert.InRange(version.Major, 3, MAX_DOTNET_MAJOR_VERSION);
         }
 
@@ -22,7 +30,7 @@ namespace DotNetCoreVersionApis
         public void RuntimeInformationFrameworkDescription()
         {
             var description = RuntimeInformation.FrameworkDescription;
-            Console.WriteLine($"RuntimeInformation.FrameworkDescription: {description}");
+            _output.WriteLine($"RuntimeInformation.FrameworkDescription: {description}");
             Assert.StartsWith(".NET", description);
         }
 
@@ -31,11 +39,11 @@ namespace DotNetCoreVersionApis
         [InlineData("corefx", typeof(Uri))]
         public void CommitHashesAreAvailable(string repo, Type type)
         {
-            Console.WriteLine($"Testing commit hashes for {repo}");
+            _output.WriteLine($"Testing commit hashes for {repo}");
 
             var attributes = (AssemblyInformationalVersionAttribute[])type.Assembly.GetCustomAttributes(typeof(AssemblyInformationalVersionAttribute),false);
             var versionAttribute = attributes[0];
-            Console.WriteLine($"AssemblyInformationVersionAttribute: {versionAttribute.InformationalVersion}");
+            _output.WriteLine($"AssemblyInformationVersionAttribute: {versionAttribute.InformationalVersion}");
 
             string[] versionParts = versionAttribute.InformationalVersion.Split("+");
             Assert.Equal(2, versionParts.Length);


### PR DESCRIPTION
Messages logged by tests to the console using Console.WriteLine and Console.Error.WriteLine are not captured by newer versions of the .NET SDK. Instead, they get lost. So we get no real feedback for failing tests in logs.

Messages logged by ITestOutputHelper are captured by the test runner, and automatically displayed by the test runner for failing tests. They don't get displayed for passing tests out of the box, but can be displayed by configuring the test logger.

See https://github.com/redhat-developer/dotnet-regular-tests/issues/370 for more discussion about the need for this.