### PR TITLE
Use traits in GitHub CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,28 +94,18 @@ jobs:
         run: |
           set -euo pipefail
 
-          ### This is very questionable, but making our CI fail because distro
-          ### .NET versions are out of date doesn't sound nice.
-          rm -rf release-version-sane
+          trait_flags=()
 
-          ### HACK: Filter tests that can't pass in Containers
-          rm -rf debugging-sos-lldb* createdump-aspnet cgroup-limit
-
-          ### HACK: RID parsing is broken on alpine:edge, so these tests fail
-          if [[ ${{ matrix.container_image }} == *'alpine:edge'* ]] ; then
-              rm -rf system-data-odbc
-          fi
-
-          ### HACK: UBI 8 is missing bash-completion, postgres, and strace packages for tests
           if [[ ${{ matrix.container_image }} == *ubi8* ]] ; then
-              rm -rf bash-completion system-data-odbc telemetry-is-off-by-default
-          fi
-          ### HACK: UBI 9 is missing postsgres and strace package for tests
-          if [[ ${{ matrix.container_image }} == *ubi9* ]] ; then
-              rm -rf system-data-odbc telemetry-is-off-by-default 
+              trait_flags+=( --trait ubi8-repos )
           fi
 
-          dotnet turkey/Turkey.dll -v --timeout 600
+          if [[ ${{ matrix.container_image }} == *ubi9* ]] ; then
+              trait_flags+=( --trait ubi9-repos )
+          fi
+
+          dotnet turkey/Turkey.dll -v --timeout 600 --trait github-ci "${trait_flags[@]}"
+        shell: bash
 
       - name: Show Logs
         if: ${{ always() }}

--- a/README.md
+++ b/README.md
@@ -13,4 +13,4 @@ $ git clone https://github.com/redhat-developer/dotnet-bunny && cd dotnet-bunny 
 ### Dependencies
 
 Dependencies(apk): babeltrace bash bash-completion binutils coreutils file findutils g++ jq libstdc++-dev lldb lttng-ust lttng-tools npm postgresql psqlodbc sed strace unixodbc zlib-dev
-Dependencies(dnf): babeltrace bash-completion bc findutils gcc-c++ jq libstdc++-devel lttng-ust lttng-tools npm postgresql-odbc postgresql-server strace unixODBC /usr/bin/file /usr/bin/free /usr/bin/lldb /usr/bin/readelf /usr/bin/su which zlib-devel
+Dependencies(dnf): awk babeltrace bash-completion bc findutils gcc-c++ jq libstdc++-devel lttng-ust lttng-tools npm postgresql-odbc postgresql-server strace unixODBC /usr/bin/file /usr/bin/free /usr/bin/lldb /usr/bin/readelf /usr/bin/su which zlib-devel

--- a/cgroup-limit/test.json
+++ b/cgroup-limit/test.json
@@ -7,6 +7,7 @@
   "type": "bash",
   "cleanup": true,
   "skipWhen": [
+    "github-ci", // github CI doesn't support this.
     "vmr-ci,os=rhel.7" // test doesn't work when it needs sudo on rhel7 because DOTNET_ROOT isn't passed through.
   ],
   "ignoredRIDs":[

--- a/createdump-aspnet/test.json
+++ b/createdump-aspnet/test.json
@@ -7,6 +7,7 @@
   "type": "bash",
   "cleanup": true,
   "skipWhen": [
+    "github-ci", // github CI can't ptrace(2)
     "runtime=mono" // 'createdump' is not included with mono
   ],
   "ignoredRIDs":[

--- a/debugging-sos-lldb-via-core/test.json
+++ b/debugging-sos-lldb-via-core/test.json
@@ -10,6 +10,7 @@
      "linux-arm" // lldb sos relies on features not implemented on arm
   ],
   "skipWhen": [
+    "github-ci", // github CI can't ptrace(2)
     "runtime=mono" // lldb sos relies on coreclr features
   ]
 }

--- a/release-version-sane/test.json
+++ b/release-version-sane/test.json
@@ -7,6 +7,7 @@
   "type": "xunit",
   "cleanup": true,
   "skipWhen": [
+    "github-ci", // Making our CI fail because distro .NET versions are out of date doesn't sound nice
     "vmr-ci" // see https://github.com/redhat-developer/dotnet-regular-tests/issues/282
   ]
 }

--- a/system-data-odbc/test.json
+++ b/system-data-odbc/test.json
@@ -8,5 +8,9 @@
   "cleanup": true,
   "ignoredRIDs":[
     "rhel7"
+  ],
+  "skipWhen": [
+    "ubi8-repos", // UBI8 repos don't contain postgressql server
+    "ubi9-repos" // UBI9 repos don't contain postgressql server
   ]
 }


### PR DESCRIPTION
Instead of the hack of rm -rf'ing specific test directories in CI, use traits to skip them in CI.

Other changes:

- Alpine edge seems to be okay with RIDs now. No need to skip them.

- bash-completion and strace seem to be available in UBI repos

Fixes: #369