### PR TITLE
Update CI to run .NET 9 and 10 on alpine

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,16 +32,6 @@ jobs:
           - "8.0"
           - "9.0"
           - "10.0"
-        exclude:
-          - container_image: docker.io/library/alpine:latest
-            dotnet_version: "9.0"
-          - container_image: docker.io/library/alpine:edge
-            dotnet_version: "9.0"
-          - container_image: docker.io/library/alpine:latest
-            dotnet_version: "10.0"
-          - container_image: docker.io/library/alpine:edge
-            dotnet_version: "10.0"
-
 
     container:
       image: ${{ matrix.container_image }}


### PR DESCRIPTION
.NET 9 and 10 are now available on alpine and edge.