### PR TITLE
Extend pgo-dynamic to work with .NET 10

### DIFF
--- a/pgo-dynamic/Program.cs
+++ b/pgo-dynamic/Program.cs
@@ -1,7 +1,7 @@
 ﻿
 // Run some loops to get the JIT compiler to optimize this code
 
-int iterations = (int.MaxValue / 100);
+int iterations = (int.MaxValue / 100000);
 if (args.Length >= 1)
 {
     iterations = int.Parse(args[0]);
@@ -11,9 +11,12 @@ Console.WriteLine($"Running {iterations} iterations.");
 
 for (int i = 0; i < iterations; i++)
 {
-    if (i % 10000 == 0)
+    for (int j = 0; j < iterations; j++)
     {
-        Console.Error.Write(".");
+        if (j % 1000 == 0)
+        {
+            Console.Error.Write(".");
+        }
     }
 }
 

--- a/pgo-dynamic/test.sh
+++ b/pgo-dynamic/test.sh
@@ -15,14 +15,14 @@ frameworks=( ./bin/Release/* )
 executable="${frameworks[0]}/publish/$name"
 
 # Set env vars to print debugging information for the JIT
-DOTNET_JitDisasmSummary=1 DOTNET_JitDisasm="<Main>$" \
+DOTNET_JitDisasmSummary=1 DOTNET_JitDisasm="<Main>$ get_Out" \
   "$executable" >stdout.log 2>stderr.log
 
 cat stderr.log
 cat stdout.log
 
 # Check the debug info for JIT to make sure dyanmic PGO is enabled
-grep -E 'Tier1-OSR @0x[a-zA-Z0-9]+ with Dynamic PGO' stdout.log
+grep -E 'Tier1-OSR @0x[a-zA-Z0-9]+ with Dynamic PGO' stdout.log || grep -E 'Tier1 with Dynamic PGO' stdout.log
 if [[ ${VERSION[0]} -ge 8 ]]; then
     grep -E '^; optimized using Dynamic PGO' stdout.log
 fi


### PR DESCRIPTION
.NET 10 uses synthesized PGO data for optimization at first, then uses dynamic PGO data, if needed. The logs may not mention OSR. That's all fine, this test is focused on checking for Dynamic PGO.

Fixes: #376