### PR TITLE
Skip dotnet-monitor-works on .NET 10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,8 @@ jobs:
           - docker.io/library/alpine:edge
           - quay.io/centos/centos:stream9
           - quay.io/centos/centos:stream10
-          - registry.fedoraproject.org/fedora:40
           - registry.fedoraproject.org/fedora:41
+          - registry.fedoraproject.org/fedora:42
           - registry.fedoraproject.org/fedora:rawhide
           - registry.access.redhat.com/ubi8
           - registry.access.redhat.com/ubi9

--- a/dotnet-monitor-works/test.json
+++ b/dotnet-monitor-works/test.json
@@ -7,6 +7,6 @@
 	"type": "bash",
 	"cleanup": false,
 	"skipWhen": [
-		"version=6,arch=s390x", // https://github.com/redhat-developer/dotnet-regular-tests/issues/325
+		"version=10", // https://github.com/redhat-developer/dotnet-regular-tests/issues/380
 	]
 }


### PR DESCRIPTION
The dotnet-monitor nuget package is not available on nuget.org, making this test always fail. Until the package is available, the results from this test are useless.

https://github.com/redhat-developer/dotnet-regular-tests/issues/380 tracks re-enabling this test with .NET 10.