### PR TITLE
Re-enable dotnet-monitor-works for .NET 10

### DIFF
--- a/dotnet-monitor-works/test.json
+++ b/dotnet-monitor-works/test.json
@@ -7,6 +7,5 @@
 	"type": "bash",
 	"cleanup": false,
 	"skipWhen": [
-		"version=10", // https://github.com/redhat-developer/dotnet-regular-tests/issues/380
 	]
 }


### PR DESCRIPTION
A dotnet-monitor package is now avialable for .NET 10 on nuget.org

Closes: #380