### PR TITLE
Fix man page test to work with .NET 10's updated man pages too

### DIFF
--- a/man-pages/test.sh
+++ b/man-pages/test.sh
@@ -7,20 +7,47 @@ helpPages=$(dotnet --help | grep -A 999 'SDK commands' | grep -E -B 999 'Common 
 
 RUNTIME_ID=$(../runtime-id)
 case $RUNTIME_ID in
-	alpine*)manPages=$(apk info -L dotnet-doc);;
-	*)manPages=$(rpm -qd $(rpm -qa | grep 'dotnet') | grep 'man1/dotnet-');;
+    alpine*)
+        manPages=$(apk info -L dotnet-doc)
+        ;;
+    *)
+        manPages=$(rpm -qd $(rpm -qa | grep 'dotnet') | grep 'man1/dotnet-')
+        ;;
 esac
+
+function man_page_exists {
+    local man_page=$1
+    echo "$manPages" | grep "$man_page"
+}
 
 failed=0
 for page in $helpPages; do
+
+    found=0
+
+    if man_page_exists "dotnet-$page"; then
+        found=1
+    fi
+
     # In .NET 10, the command is shown as 'solution'. sln is a working alias,
     # like older versions of .NET.  However, the man page is name 'sln'.
-    if [[ "$page" == solution ]]; then
-        page=sln
+    if [[ $found == 0 ]] && [[ "$page" == solution ]]; then
+        new_page=sln
+        if man_page_exists "dotnet-$new_page"; then
+            found=1
+        fi
     fi
-    if echo "$manPages" | grep "dotnet-$page"; then
-        true
-    else
+
+    # In man pages provided by .NET 10 (but visible to a .NET 8 or 9 SDK),
+    # some commands like 'list' and 'remove' have a man page only present for
+    # the longer form of the command such as 'dotnet package list'.
+    if [[ $found == 0 ]] && { [[ "$page" == "add" ]] || [[ "$page" == "list" ]] || [[ "$page" == "remove" ]]; } ; then
+        if man_page_exists "dotnet-package-$page"; then
+            found=1
+        fi
+    fi
+
+    if [[ $found == 0 ]]; then
         echo "error: Man page for dotnet-$page not found: FAIL"
         failed=1
     fi


### PR DESCRIPTION
It's possible to use a .NET 8 SDK (dotnet-sdk-8.0) with man pages actually provided by the .NET 10 host (dotnet-host-10.0), because .NET 10 host gets them from the .NET 10 SDK.

Fix the issues that come up in that case, where some man pages are only available under the newer name.