### PR TITLE
Ignore winformscontrollib for .NET 10 template

### DIFF
--- a/template-test/test.sh
+++ b/template-test/test.sh
@@ -312,6 +312,7 @@ templateIgnoreList=(
     mstest-playwright
     nunit-playwright
     winforms
+    winformscontrollib
     winformslib
     wpf
     wpfcustomcontrollib


### PR DESCRIPTION
Like other win templates, this isn't something we expect to work.