### PR TITLE
Fix typo in tools-in-path skipping

### DIFF
--- a/tools-in-path/test.json
+++ b/tools-in-path/test.json
@@ -7,8 +7,8 @@
   "cleanup": true,
   "skipWhen": [
     "vmr-ci", // tools PATH not configured (tar.gz build)
-    "os=fedora.34", // Fedora packages stopped updating PATH with 44
-    "os=fedora.35"
+    "os=fedora.44", // Fedora packages stopped updating PATH with 44
+    "os=fedora.45"
   ],
   "ignoredRIDs": [
   ]


### PR DESCRIPTION
Should be 44, not 34.