### PR TITLE
Log lldb version when using it

### DIFF
--- a/debugging-sos-lldb-via-core/test.sh
+++ b/debugging-sos-lldb-via-core/test.sh
@@ -49,6 +49,7 @@ if ! command -v lldb ; then
     echo "lldb is not installed"
     exit 1
 fi
+{ rpm -qa | grep lldb; } || { apk list -i | grep lldb; } || true
 
 no_server=("/nodeReuse:false" "/p:UseSharedCompilation=false" "/p:UseRazorBuildServer=false")
 


### PR DESCRIPTION
I have seen an unexpected failure when using lldb to debug a core in a CI enviornment. Log additional details to help make it easier to reproduce/fix the problem.