### PR TITLE
publish-aspnet-selfcontained: disable on Alpine Linux for dotnet9

### DIFF
--- a/publish-aspnet-selfcontained/test.json
+++ b/publish-aspnet-selfcontained/test.json
@@ -5,6 +5,9 @@
   "version": "8.0",
   "versionSpecific": false,
   "type": "bash",
-  "cleanup": true
+  "cleanup": true,
+  "skipWhen": [
+    "os=alpine,version=9",// see https://github.com/redhat-developer/dotnet-regular-tests/issues/405
+  ]
 }
 


### PR DESCRIPTION
Test unit is unstable, opened https://github.com/redhat-developer/dotnet-regular-tests/issues/405