### PR TITLE
debugging-via-dotnet-dump: Remove "linux-arm" from ignoredRIDs

### DIFF
--- a/debugging-via-dotnet-dump/test.json
+++ b/debugging-via-dotnet-dump/test.json
@@ -8,7 +8,6 @@
   "cleanup": true,
   "timeoutMultiplier": 2,
   "ignoredRIDs": [
-     "linux-arm" // dotnet-dump relies on features not implemented on arm
   ],
   "skipWhen": [
     "runtime=mono" // dotnet-dump relies on coreclr features


### PR DESCRIPTION
Removing the "linux-arm" RID from the ignoredRIDs section for debugging-via-dotnet-dump as the test passes on arm. Also the rid for arm is "linux-arm64" so this test was running on arm machines regardless.

Closes #236 