### PR TITLE
debugging-sos-lldb-via-core: work around lldb deadlock.

### DIFF
--- a/debugging-sos-lldb-via-core/test.sh
+++ b/debugging-sos-lldb-via-core/test.sh
@@ -42,6 +42,12 @@ dotnet tool install -g dotnet-dump
 
 dotnet sos install
 
+# work around lldb deadlock in v21.1.8 (https://github.com/redhat-developer/dotnet-regular-tests/issues/392#issuecomment-4068491555).
+if lldb --version | grep -q "21.1.8"; then
+    LINE='settings set target.parallel-module-load false'
+    grep -qF "$LINE" ~/.lldbinit || echo "$LINE" >> ~/.lldbinit
+fi
+
 framework_dir=$(../dotnet-directory --framework "${sdk_version}")
 test -f "${framework_dir}/createdump"
 


### PR DESCRIPTION
This works around the deadlock on Fedora 43, RHEL 9 and RHEL 10.

Fixes https://github.com/redhat-developer/dotnet-regular-tests/issues/392