### PR TITLE
debugging-via-dotnet-dump: remove WeakLong check.

### DIFF
--- a/debugging-via-dotnet-dump/test.sh
+++ b/debugging-via-dotnet-dump/test.sh
@@ -429,7 +429,7 @@ cat dump.out
 heading "gchandles"
 dump-analyze 'gchandles' > dump.out
 cat dump.out
-for reference in Strong WeakShort WeakLong Dependent; do
+for reference in Strong WeakShort Dependent; do
     if [[ $(cut -d' ' -f2 dump.out | grep -cF "$reference") -lt 2 ]]; then
         echo "fail: too few references of type $reference"
         exit 2


### PR DESCRIPTION
WeakLong handles are not reliably present in every dump causing intermittent test failures.

The remaining checks still provide sufficient coverage for gchandles validation.

Fixes https://github.com/redhat-developer/dotnet-regular-tests/issues/407.