### PR TITLE
Add mcpserver to ignored templates

### DIFF
--- a/template-test/test.sh
+++ b/template-test/test.sh
@@ -372,6 +372,9 @@ templateIgnoreList=(
     mstest-playwright
     nunit-playwright
 
+    # vulnerable at the moment, which fails tests - https://github.com/advisories/GHSA-v5pm-xwqc-g5wc
+    mcpserver
+    
     winforms
     winformscontrollib
     winformslib


### PR DESCRIPTION
New template in .NET 10, but at the moment there's a vulnerability which causes it to fail tests:

https://github.com/advisories/GHSA-v5pm-xwqc-g5wc