### PR TITLE
Ignore the correct template (webapi)

### DIFF
--- a/template-test/test.sh
+++ b/template-test/test.sh
@@ -372,8 +372,8 @@ templateIgnoreList=(
     mstest-playwright
     nunit-playwright
 
-    # vulnerable at the moment, which fails tests - https://github.com/advisories/GHSA-v5pm-xwqc-g5wc
-    mcpserver
+    # 'Microsoft.OpenApi' 2.0.0 is vulnerable at the moment, which fails tests - https://github.com/advisories/GHSA-v5pm-xwqc-g5wc
+    webapi
     
     winforms
     winformscontrollib


### PR DESCRIPTION
webapi is the one using a package that's currently vulnerable. mcpserver was actually fine, just missing from the list (#424).