### PR TITLE
tls-uses-pqc: use already-loaded libssl instead

### DIFF
--- a/tls-uses-pqc/Program.cs
+++ b/tls-uses-pqc/Program.cs
@@ -59,22 +59,34 @@ return 1;
 // Use OpenSSL interop to get the negotiated key exchange group (SslStream doesn't expose this information).
 static void SetOpenSSLImportResolver()
 {
-    // Use the latest OpenSSL version on the system.
     NativeLibrary.SetDllImportResolver(Assembly.GetExecutingAssembly(), (name, assembly, searchPath) =>
     {
         Console.WriteLine($"Resolving {name}...");
 
         if (name == "libssl")
         {
-            if (NativeLibrary.TryLoad("libssl.so.4", assembly, searchPath, out var h) ||
-                NativeLibrary.TryLoad("libssl.so.3", assembly, searchPath, out h))
+            // The runtime can pick a libssl version based on the build
+            // configuration (portable vs non-portable) and/or version-priority
+            // and/or user-overrides. Instead of hardcoding or guessing, find
+            // the version of libssl.so already loaded into the current
+            // process. By the time this runs, we have already used TLS
+            // operations like SslStream(), so some version of libssl must be
+            // already loaded on *nix.
+            var procSelfMaps = File.ReadAllText("/proc/self/maps");
+            var libsslPath = procSelfMaps.Split(new string[]{ Environment.NewLine }, StringSplitOptions.None)
+                             .Select(line => line.Split(' ').LastOrDefault()?.Trim())
+                             .FirstOrDefault(path => !string.IsNullOrEmpty(path) && path.Contains("libssl.so"));
+
+            if (!string.IsNullOrEmpty(libsslPath) &&
+                NativeLibrary.TryLoad(libsslPath, assembly, searchPath, out var h))
             {
                 return h;
             }
+
             Console.WriteLine($"error: Cannot resolve {name}.");
             Console.WriteLine();
             Console.WriteLine("Mapped files:");
-            Console.WriteLine(File.ReadAllText("/proc/self/maps"));
+            Console.WriteLine(procSelfMaps);
             Console.WriteLine();
             Console.WriteLine("libssl files in /usr/lib*:");
             try


### PR DESCRIPTION
Preferring a fixed libssl.so.4 (OpenSSL 4) or .so.3 may not match with
what the runtime is using. Always use the one already picked by the
runtime.

As a concrete example, the source-built SDK on Fedora Rawhide is
currently non-portably linked against OpenSSL 3, but the test was
calling the function in libssl.so.4, which was not working.