### PR TITLE
Add blazorwasm-servicedefaults to dotnet11Templates and skip mcpserver for .NET10 on ppc64le, s390x and arm

### DIFF
--- a/template-test/test.sh
+++ b/template-test/test.sh
@@ -19,6 +19,7 @@ dotnet11Templates=(
     apicontroller
     blazor
     blazorwasm
+    blazorwasm-servicedefaults
     blazorwebworker
     buildprops
     buildtargets
@@ -491,7 +492,13 @@ function testTemplate {
         echo "SKIP skipping webapiaot on ppc64/s390x/armv7"
         return
     fi
-
+    
+    if [[ ( $(uname -m) == "s390x" ||  $(uname -m) == "ppc64le" || $(uname -m) == "armv7" || $(uname -m) == "armv8l" ) && ( "${templateName}" == "mcpserver" ) ]]; then
+        # mcpserver relies on Microsoft.NETCore.App.Runtime, which will not even restore on mono (ppc64le/s390x) and arm, skip it
+        echo "SKIP skipping mcpserver on ppc64/s390x/armv7"
+        return
+    fi
+    
     if [[ ${action} = project,* ]] ; then
         dotnet new console 2>&1 | tee "${templateName}.log"
         action=$(echo "${action}" | sed -E "s|project,||")


### PR DESCRIPTION
`blazorwasm-servicedefaults` New template in .NET11 and skip `mcpserver` for .NET 10 on ppc64le, s390x, and arm due to missing Microsoft.NETCore.App.Runtime.linux-ppc64le, Microsoft.AspNetCore.App.Runtime.linux-ppc64le, and Microsoft.NETCore.App.Host.linux-ppc64le packages
error
```
Restoring /var/tmp/tmp.eHuy6UkhlU/mcpserver_template/mcpserver_template.csproj:
  Determining projects to restore...
/var/tmp/tmp.eHuy6UkhlU/mcpserver_template/mcpserver_template.csproj : error NU1101: Unable to find package Microsoft.NETCore.App.Runtime.linux-ppc64le. No packages exist with this id in source(s): 0, 1
/var/tmp/tmp.eHuy6UkhlU/mcpserver_template/mcpserver_template.csproj : error NU1101: Unable to find package Microsoft.AspNetCore.App.Runtime.linux-ppc64le. No packages exist with this id in source(s): 0, 1
/var/tmp/tmp.eHuy6UkhlU/mcpserver_template/mcpserver_template.csproj : error NU1101: Unable to find package Microsoft.NETCore.App.Host.linux-ppc64le. No packages exist with this id in source(s): 0, 1
  Failed to restore /var/tmp/tmp.eHuy6UkhlU/mcpserver_template/mcpserver_template.csproj (in 18.17 sec).
Restore failed.
Post action failed.
```
@omajid 